### PR TITLE
Call callback with error when there is a browser switch error

### DIFF
--- a/PopupBridge/build.gradle
+++ b/PopupBridge/build.gradle
@@ -20,7 +20,7 @@ android {
 }
 
 dependencies {
-    compile 'com.braintreepayments:browser-switch:0.1.1'
+    compile 'com.braintreepayments:browser-switch:0.1.2'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.7.11'

--- a/PopupBridge/src/main/java/com/braintreepayments/popupbridge/PopupBridge.java
+++ b/PopupBridge/src/main/java/com/braintreepayments/popupbridge/PopupBridge.java
@@ -95,15 +95,15 @@ public class PopupBridge extends BrowserSwitchFragment {
 
     @Override
     public void onBrowserSwitchResult(int requestCode, BrowserSwitchResult result, Uri returnUri) {
-        if (returnUri == null || !returnUri.getScheme().equals(getReturnUrlScheme()) ||
-                !returnUri.getHost().equals(POPUP_BRIDGE_URL_HOST)) {
-            return;
-        }
-
         String error = null;
         String payload = null;
 
-        if (result != BrowserSwitchResult.CANCELED) {
+        if (result == BrowserSwitchResult.OK) {
+            if (returnUri == null || !returnUri.getScheme().equals(getReturnUrlScheme()) ||
+                    !returnUri.getHost().equals(POPUP_BRIDGE_URL_HOST)) {
+                return;
+            }
+
             JSONObject json = new JSONObject();
             JSONObject queryItems = new JSONObject();
 
@@ -125,6 +125,8 @@ public class PopupBridge extends BrowserSwitchFragment {
             } catch (JSONException ignored) {}
 
             payload = json.toString();
+        } else if (result == BrowserSwitchResult.ERROR) {
+            error = "new Error('" + result.getErrorMessage() + "')";
         }
 
         mWebView.evaluateJavascript(String.format("window.popupBridge.onComplete(%s, %s);", error,

--- a/PopupBridge/src/main/java/com/braintreepayments/popupbridge/PopupBridge.java
+++ b/PopupBridge/src/main/java/com/braintreepayments/popupbridge/PopupBridge.java
@@ -19,7 +19,6 @@ import java.util.Set;
 
 public class PopupBridge extends BrowserSwitchFragment {
 
-    public static final int POPUP_BRIDGE_REQUEST_CODE = 13592;
     public static final String POPUP_BRIDGE_NAME = "popupBridge";
     public static final String POPUP_BRIDGE_URL_HOST = "popupbridgev1";
 

--- a/PopupBridge/src/test/java/com/braintreepayments/popupbridge/PopupBridgeTest.java
+++ b/PopupBridge/src/test/java/com/braintreepayments/popupbridge/PopupBridgeTest.java
@@ -22,6 +22,7 @@ import org.mockito.ArgumentCaptor;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
+import org.robolectric.util.ReflectionHelpers;
 
 import java.util.Collections;
 
@@ -38,7 +39,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 19)
-public class TestPopupBridge {
+public class PopupBridgeTest {
 
     private Activity mActivity;
     private PopupBridge mPopupBridge;
@@ -167,6 +168,17 @@ public class TestPopupBridge {
         JSONObject payload = new JSONObject(mWebView.mPayload);
         assertEquals(payload.getString("path"), "/mypath");
         assertEquals(payload.getJSONObject("queryItems").length(), 0);
+    }
+
+    @Test
+    public void onBrowserSwitchResult_whenResultIsError_reportsError() {
+        BrowserSwitchResult result = BrowserSwitchResult.ERROR;
+        ReflectionHelpers.callInstanceMethod(result, "setErrorMessage",
+                new ReflectionHelpers.ClassParameter<>(String.class, "Browser switch error"));
+
+        mPopupBridge.onBrowserSwitchResult(1, result, null);
+
+        assertEquals("new Error('Browser switch error')", mWebView.mError);
     }
 
     @Test

--- a/PopupBridgeExample/build.gradle
+++ b/PopupBridgeExample/build.gradle
@@ -16,7 +16,7 @@ android {
 
 dependencies {
     compile project(':PopupBridge')
-    compile 'com.android.support:appcompat-v7:25.2.0'
+    compile 'com.android.support:appcompat-v7:25.3.0'
 
-    androidTestCompile 'com.lukekorth:device-automator:0.1.0'
+    androidTestCompile 'com.lukekorth:device-automator:0.1.1'
 }


### PR DESCRIPTION
Browser switch errors are usually setup errors. This passes the error message through to `window.popupBridge.onComplete`.