### PR TITLE
Run evaluateJavascript on the UI thread

### DIFF
--- a/PopupBridge/src/main/java/com/braintreepayments/popupbridge/PopupBridge.java
+++ b/PopupBridge/src/main/java/com/braintreepayments/popupbridge/PopupBridge.java
@@ -137,8 +137,16 @@ public class PopupBridge extends BrowserSwitchFragment {
             error = "new Error('" + result.getErrorMessage() + "')";
         }
 
-        mWebView.evaluateJavascript(String.format("window.popupBridge.onComplete(%s, %s);", error,
-                payload), null);
+        final String postError = error;
+        final String postPayload = payload;
+
+        mWebView.post(new Runnable() {
+            @Override
+            public void run() {
+                mWebView.evaluateJavascript(String.format("window.popupBridge.onComplete(%s, %s);",
+                        postError, postPayload), null);
+            }
+        });
     }
 
     @Override

--- a/PopupBridge/src/main/java/com/braintreepayments/popupbridge/PopupBridge.java
+++ b/PopupBridge/src/main/java/com/braintreepayments/popupbridge/PopupBridge.java
@@ -93,7 +93,7 @@ public class PopupBridge extends BrowserSwitchFragment {
         setRetainInstance(true);
     }
 
-    public void runJavaScriptInWebview(final String script) {
+    private void runJavaScriptInWebView(final String script) {
         mWebView.post(new Runnable() {
             @Override
             public void run() {
@@ -108,7 +108,7 @@ public class PopupBridge extends BrowserSwitchFragment {
         String payload = null;
 
         if (result == BrowserSwitchResult.CANCELED) {
-            runJavaScriptInWebview(""
+            runJavaScriptInWebView(""
                 + "if (typeof window.popupBridge.onCancel === 'function') {"
                 + "  window.popupBridge.onCancel();"
                 + "} else {"
@@ -146,7 +146,7 @@ public class PopupBridge extends BrowserSwitchFragment {
             error = "new Error('" + result.getErrorMessage() + "')";
         }
 
-        runJavaScriptInWebview(String.format("window.popupBridge.onComplete(%s, %s);", error, payload));
+        runJavaScriptInWebView(String.format("window.popupBridge.onComplete(%s, %s);", error, payload));
     }
 
     @Override

--- a/PopupBridge/src/main/java/com/braintreepayments/popupbridge/PopupBridge.java
+++ b/PopupBridge/src/main/java/com/braintreepayments/popupbridge/PopupBridge.java
@@ -93,18 +93,27 @@ public class PopupBridge extends BrowserSwitchFragment {
         setRetainInstance(true);
     }
 
+    public void runJavaScriptInWebview(final String script) {
+        mWebView.post(new Runnable() {
+            @Override
+            public void run() {
+                mWebView.evaluateJavascript(script, null);
+            }
+        });
+    }
+
     @Override
     public void onBrowserSwitchResult(int requestCode, BrowserSwitchResult result, Uri returnUri) {
         String error = null;
         String payload = null;
 
         if (result == BrowserSwitchResult.CANCELED) {
-            mWebView.evaluateJavascript(""
+            runJavaScriptInWebview(""
                 + "if (typeof window.popupBridge.onCancel === 'function') {"
                 + "  window.popupBridge.onCancel();"
                 + "} else {"
                 + "  window.popupBridge.onComplete(null, null);"
-                + "}", null);
+                + "}");
             return;
         } else if (result == BrowserSwitchResult.OK) {
             if (returnUri == null || !returnUri.getScheme().equals(getReturnUrlScheme()) ||
@@ -137,16 +146,7 @@ public class PopupBridge extends BrowserSwitchFragment {
             error = "new Error('" + result.getErrorMessage() + "')";
         }
 
-        final String postError = error;
-        final String postPayload = payload;
-
-        mWebView.post(new Runnable() {
-            @Override
-            public void run() {
-                mWebView.evaluateJavascript(String.format("window.popupBridge.onComplete(%s, %s);",
-                        postError, postPayload), null);
-            }
-        });
+        runJavaScriptInWebview(String.format("window.popupBridge.onComplete(%s, %s);", error, payload));
     }
 
     @Override


### PR DESCRIPTION
Wrapping the `evaluateJavascript` in a `View#post` to make sure it is being ran on the same thread as the `WebView`.

`evaluateJavascript` (along with all the `WebView` public methods) call [`WebView#checkThread`](https://github.com/aosp-mirror/platform_frameworks_base/blob/master/core/java/android/webkit/WebView.java#L1054) which checks that the method was called on the same thread as the `WebView`'s thread.

This should fix #10.

@braintree/team-dx 