### PR TITLE
Relax activity requirement to FragmentActivity

### DIFF
--- a/PopupBridge/src/main/java/com/braintreepayments/popupbridge/PopupBridge.java
+++ b/PopupBridge/src/main/java/com/braintreepayments/popupbridge/PopupBridge.java
@@ -15,8 +15,8 @@ import org.json.JSONObject;
 
 import java.util.Set;
 
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 
 public class PopupBridge extends BrowserSwitchFragment {
@@ -33,17 +33,17 @@ public class PopupBridge extends BrowserSwitchFragment {
     public PopupBridge() {}
 
     /**
-     * Create a new instance of {@link PopupBridge} and add it to the {@link AppCompatActivity}'s {@link android.support.v4.app.FragmentManager}.
+     * Create a new instance of {@link PopupBridge} and add it to the {@link FragmentActivity}'s {@link android.support.v4.app.FragmentManager}.
      *
      * This will enable JavaScript in your WebView.
      *
-     * @param activity The {@link AppCompatActivity} to add the {@link Fragment} to.
+     * @param activity The {@link FragmentActivity} to add the {@link Fragment} to.
      * @param webView The {@link WebView} to enable for PopupBridge.
      * @return {@link PopupBridge}
      * @throws IllegalArgumentException If the activity is not valid or the fragment cannot be added.
      */
     @SuppressLint("SetJavaScriptEnabled")
-    public static PopupBridge newInstance(AppCompatActivity activity, WebView webView) throws IllegalArgumentException {
+    public static PopupBridge newInstance(FragmentActivity activity, WebView webView) throws IllegalArgumentException {
         if (activity == null) {
             throw new IllegalArgumentException("Activity is null");
         }


### PR DESCRIPTION
There is no need to request an instance of AppCompatActivity. Among other things, this allows testing with 'androidx.fragment-testing', which only provides a FragmentActivity to fragments.