### PR TITLE
Update integration tests to assert that text exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,7 @@ android:
     - extra-android-support
     - extra-android-m2repository
     - extra-google-m2repository
-before_script:
-  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
-  - emulator -avd test -skin WXGA720 -no-audio -no-window &
-  - android-wait-for-emulator
-  - sleep 60
-  - adb shell input keyevent 82
 before_install:
   - yes | sdkmanager "platforms;android-28"
-script: ./gradlew clean lint test connectedAndroidTest
+script: ./gradlew --info clean lint test
 after_success: ./deploy_snapshot.sh

--- a/PopupBridgeExample/src/androidTest/java/com.braintreepayments.popupbridge.example.test/PopupBridgeTest.java
+++ b/PopupBridgeExample/src/androidTest/java/com.braintreepayments.popupbridge.example.test/PopupBridgeTest.java
@@ -11,9 +11,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.lukekorth.deviceautomator.AutomatorAction.click;
+import static com.lukekorth.deviceautomator.AutomatorAssertion.text;
 import static com.lukekorth.deviceautomator.DeviceAutomator.onDevice;
 import static com.lukekorth.deviceautomator.UiObjectMatcher.withContentDescription;
 import static com.lukekorth.deviceautomator.UiObjectMatcher.withText;
+import static org.hamcrest.CoreMatchers.containsString;
 
 @RunWith(AndroidJUnit4.class)
 public class PopupBridgeTest {
@@ -46,7 +48,8 @@ public class PopupBridgeTest {
         onViewWithText("Launch Popup").perform(click());
         onViewWithText("I don't like any of these colors")
                 .waitForExists(BROWSER_TIMEOUT).perform(click());
-        onViewWithText("You do not like any of these colors").waitForExists();
+        onViewWithText("PopupBridge Example").waitForExists();
+        onViewWithText("You did not like any of our colors").check(text(containsString("You did not like any of our colors")));
     }
 
     @Test(timeout = 50000)
@@ -55,14 +58,15 @@ public class PopupBridgeTest {
         onViewWithText("I don't like any of these colors")
                 .waitForExists(BROWSER_TIMEOUT);
         onDevice().pressBack();
-        onViewWithText("You did not choose a color").waitForExists();
+        onViewWithText("PopupBridge Example").waitForExists();
+        onViewWithText("You did not choose a color").check(text(containsString("You did not choose a color")));
     }
 
     private void testColor(String color) {
         onViewWithText("Launch Popup").perform(click());
         onViewWithText(color).waitForExists(BROWSER_TIMEOUT).perform(click());
         onViewWithText("Your favorite color:").waitForExists();
-        onViewWithText(color.toLowerCase()).waitForExists();
+        onViewWithText(color.toLowerCase()).check(text(containsString(color.toLowerCase())));
     }
 
     private DeviceAutomator onViewWithText(String text) {

--- a/PopupBridgeExample/src/androidTest/java/com.braintreepayments.popupbridge.example.test/PopupBridgeTest.java
+++ b/PopupBridgeExample/src/androidTest/java/com.braintreepayments.popupbridge.example.test/PopupBridgeTest.java
@@ -2,7 +2,7 @@ package com.braintreepayments.popupbridge.example.test;
 
 import android.os.Build;
 
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
 
 import com.lukekorth.deviceautomator.DeviceAutomator;
 
@@ -11,13 +11,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.lukekorth.deviceautomator.AutomatorAction.click;
-import static com.lukekorth.deviceautomator.AutomatorAssertion.text;
 import static com.lukekorth.deviceautomator.DeviceAutomator.onDevice;
 import static com.lukekorth.deviceautomator.UiObjectMatcher.withContentDescription;
 import static com.lukekorth.deviceautomator.UiObjectMatcher.withText;
-import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertTrue;
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(AndroidJUnit4ClassRunner.class)
 public class PopupBridgeTest {
 
     private static final long BROWSER_TIMEOUT = 20000;
@@ -48,8 +47,7 @@ public class PopupBridgeTest {
         onViewWithText("Launch Popup").perform(click());
         onViewWithText("I don't like any of these colors")
                 .waitForExists(BROWSER_TIMEOUT).perform(click());
-        onViewWithText("PopupBridge Example").waitForExists();
-        onViewWithText("You did not like any of our colors").check(text(containsString("You did not like any of our colors")));
+        assertTrue(onDevice(withText("You did not like any of our colors")).exists());
     }
 
     @Test(timeout = 50000)
@@ -58,15 +56,14 @@ public class PopupBridgeTest {
         onViewWithText("I don't like any of these colors")
                 .waitForExists(BROWSER_TIMEOUT);
         onDevice().pressBack();
-        onViewWithText("PopupBridge Example").waitForExists();
-        onViewWithText("You did not choose a color").check(text(containsString("You did not choose a color")));
+        assertTrue(onDevice(withText("You did not choose a color")).exists());
     }
 
     private void testColor(String color) {
         onViewWithText("Launch Popup").perform(click());
         onViewWithText(color).waitForExists(BROWSER_TIMEOUT).perform(click());
         onViewWithText("Your favorite color:").waitForExists();
-        onViewWithText(color.toLowerCase()).check(text(containsString(color.toLowerCase())));
+        assertTrue(onDevice(withText(color.toLowerCase())).exists());
     }
 
     private DeviceAutomator onViewWithText(String text) {


### PR DESCRIPTION
### Summary of changes

 - Update integration tests to use `assertTrue()` instead of `waitForExists()` only.
 - Remove connectedAndroidTest and wait for emulator from travis.yml

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors

- @sarahkoop 