### PR TITLE
Add SourcesJar and JavadocsJar to Maven Publish

### DIFF
--- a/PopupBridge/build.gradle
+++ b/PopupBridge/build.gradle
@@ -48,11 +48,6 @@ task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
 }
 
-artifacts {
-    archives javadocsJar
-    archives sourcesJar
-}
-
 signing {
     required {
         !version.endsWith("SNAPSHOT") && !version.endsWith("DEVELOPMENT")
@@ -73,6 +68,9 @@ afterEvaluate {
         publications {
             release(MavenPublication) {
                 from components.release
+
+                artifact sourcesJar
+                artifact javadocsJar
 
                 groupId = 'com.braintreepayments.api'
                 artifactId = 'popup-bridge'


### PR DESCRIPTION
### Summary of changes

 - Fix an issue that caused javadocs and source jars to be omitted from `maven-publish` artifacts

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
- @sshropshire