### PR TITLE
Android 12 Updates v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 
 * Upgrade `targetSdkVersion` and `compileSdkVersion` to API 31
-* Bump `browser-switch` version to `2.X.X`
+* Bump `browser-switch` version to `2.1.0`
 
 ## 4.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PopupBridge Android Release Notes
 
+## unreleased
+
+* Upgrade `targetSdkVersion` and `compileSdkVersion` to API 31
+* Bump `browser-switch` version to `2.X.X`
+
 ## 4.0.1
 
 * Upgrade browser-switch to 2.0.1

--- a/Demo/build.gradle
+++ b/Demo/build.gradle
@@ -23,7 +23,8 @@ android {
 
 dependencies {
     implementation project(':PopupBridge')
-    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
 
     androidTestImplementation 'com.braintreepayments:device-automator:1.0.0'
+    androidTestImplementation 'androidx.test:core:1.4.0'
 }

--- a/Demo/src/main/AndroidManifest.xml
+++ b/Demo/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         android:theme="@style/Theme.AppCompat.Light">
 
         <activity android:name=".PopupActivity"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/Demo/src/main/AndroidManifest.xml
+++ b/Demo/src/main/AndroidManifest.xml
@@ -10,7 +10,9 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.Light">
 
-        <activity android:name=".PopupActivity" android:launchMode="singleTop">
+        <activity android:name=".PopupActivity"
+            android:launchMode="singleTop"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -19,7 +21,8 @@
             </intent-filter>
         </activity>
 
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/PopupBridge/build.gradle
+++ b/PopupBridge/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion '30.0.2'
+    buildToolsVersion '30.0.3'
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
@@ -22,11 +22,11 @@ android {
 }
 
 dependencies {
-    implementation 'com.braintreepayments.api:browser-switch:2.0.1'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'com.braintreepayments.api:browser-switch:2.0.3-SNAPSHOT'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.8.9'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:3.6.0'
     testImplementation 'org.robolectric:robolectric:4.1'
 }
 

--- a/PopupBridge/build.gradle
+++ b/PopupBridge/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.braintreepayments.api:browser-switch:2.0.3-SNAPSHOT'
+    implementation 'com.braintreepayments.api:browser-switch:2.1.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
 
     testImplementation 'junit:junit:4.13.2'

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Quick Start
 
   ```xml
   <activity android:name="com.braintreepayments.popupbridge.PopupBridgeActivity"
-      android:launchMode="singleTask">
+      android:launchMode="singleTask"
+      android:exported="true">
       <intent-filter>
           <action android:name="android.intent.action.VIEW" />
           <category android:name="android.intent.category.DEFAULT" />
@@ -45,6 +46,7 @@ Quick Start
       </intent-filter>
   </activity>
   ```
+Note: `android:exported` is required if your app compile SDK version is API 31 (Android 12) or later.
 
 1. Include PopupBridge in your app code:
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        mavenLocal()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'de.marcphilipp.gradle:nexus-publish-plugin:0.4.0'
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2'
     }
@@ -19,9 +19,9 @@ plugins {
 
 version '4.0.2-SNAPSHOT'
 ext {
-    compileSdkVersion = 30
+    compileSdkVersion = 31
     minSdkVersion = 21
-    targetSdkVersion = 30
+    targetSdkVersion = 31
     versionCode = 15
     versionName = version
 }
@@ -30,6 +30,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        mavenLocal()
     }
 }
 

--- a/v4_MIGRATION.md
+++ b/v4_MIGRATION.md
@@ -8,7 +8,7 @@ First, update the popup bridge dependency version in your `build.gradle` file:
 
 ```groovy
 dependencies {
-  implementation 'com.braintreepayments.api:popup-bridge:4.0.0-beta3'
+  implementation 'com.braintreepayments.api:popup-bridge:4.0.1'
 }
 ```
 
@@ -17,7 +17,8 @@ dependencies {
 Next, in the `AndroidManifest.xml`, migrate the `intent-filter` from your v3 integration into an activity you own:
 
 ```xml
-<activity android:name="com.company.app.MyPopupBridgeActivity">
+<activity android:name="com.company.app.MyPopupBridgeActivity"
+    android:exported="true">
     ...
     <intent-filter>
         <action android:name="android.intent.action.VIEW"/>
@@ -29,6 +30,7 @@ Next, in the `AndroidManifest.xml`, migrate the `intent-filter` from your v3 int
 ```
 
 **Note**: The scheme you define must use all lowercase letters. This is due to [scheme matching on the Android framework being case sensitive, expecting lower case](https://developer.android.com/guide/topics/manifest/data-element#scheme).
+**Note**: `android:exported` is required if your app compile SDK version is API 31 (Android 12) or later.
 
 ## Usage
 


### PR DESCRIPTION
### Summary of changes

 - Upgrade `targetSdkVersion` and `compileSdkVersion` to API 31
 - Bump `browser-switch` version to `2.1.0`

**Note**: The issue with switching to the Venmo app has been resolved, but on return to popup-bridge, we can't see the result correctly. After testing, I think the issue is with the JS in our example site, not popup-bridge. I tested on both Android 11 and Android 12 devices and am able to return from the Venmo app switch with a success payload and a nonce - the issue occurs with running the success javascript in the webview. This behavior is happening on the master branch too, so I don't think there is any issue related to this PR. 

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 