### PR TITLE
Deep Link Activity Recovery

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/popupbridge/demo/MainActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/popupbridge/demo/MainActivity.java
@@ -23,7 +23,7 @@ public class MainActivity extends AppCompatActivity {
 
     private void switchToWebView(String url) {
         Intent intent = new Intent(this, PopupActivity.class);
-        intent.putExtra("url", url);
+        intent.putExtra(PopupActivity.BUNDLE_KEY_URL, url);
         startActivity(intent);
     }
 

--- a/Demo/src/main/java/com/braintreepayments/popupbridge/demo/PopupActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/popupbridge/demo/PopupActivity.java
@@ -1,7 +1,9 @@
 package com.braintreepayments.popupbridge.demo;
 
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.webkit.WebView;
 
@@ -10,6 +12,8 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.braintreepayments.api.PopupBridgeClient;
 
 public class PopupActivity extends AppCompatActivity {
+
+    static final String BUNDLE_KEY_URL = "PopupActivity.BUNDLE_KEY_URL";
 
     private WebView mWebView;
     private PopupBridgeClient mPopupBridgeClient;
@@ -23,7 +27,14 @@ public class PopupActivity extends AppCompatActivity {
         mPopupBridgeClient = new PopupBridgeClient(this, mWebView, "com.braintreepayments.popupbridgeexample");
         mPopupBridgeClient.setErrorListener(error -> showDialog(error.getMessage()));
 
-        mWebView.loadUrl(getIntent().getStringExtra("url"));
+        String url = getIntent().getStringExtra(BUNDLE_KEY_URL);
+        if (url == null) {
+            // assume launch is from deep link; fetch url from persistent storage
+            url = getPendingURLFromPersistentStorage();
+        }
+
+        mWebView.loadUrl(url);
+        savePendingURL(url);
     }
 
     @Override
@@ -43,5 +54,22 @@ public class PopupActivity extends AppCompatActivity {
                 .setMessage(message)
                 .setPositiveButton(android.R.string.ok, (dialog, which) -> dialog.dismiss())
                 .show();
+    }
+
+    private String getPendingURLFromPersistentStorage() {
+        SharedPreferences sharedPreferences = getPreferences(Context.MODE_PRIVATE);
+        if (sharedPreferences != null) {
+            return sharedPreferences.getString(BUNDLE_KEY_URL, null);
+        }
+        return null;
+    }
+
+    private void savePendingURL(String url) {
+        SharedPreferences sharedPreferences = getPreferences(Context.MODE_PRIVATE);
+        if (sharedPreferences != null) {
+            sharedPreferences.edit()
+                    .putString(BUNDLE_KEY_URL, url)
+                    .apply();
+        }
     }
 }


### PR DESCRIPTION
### Summary of changes

 - This PR supports activity recreation in the Demo App
 - When a new `PopupActivity` is instantiated from a deep link and a result is pending, we reload the last accessed URL.

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 