### PR TITLE
Notify caller of browser switch failure

### DIFF
--- a/PopupBridge/src/main/java/com/braintreepayments/api/PopupBridgeClient.kt
+++ b/PopupBridge/src/main/java/com/braintreepayments/api/PopupBridgeClient.kt
@@ -124,7 +124,9 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
 
             when (val browserSwitchFinalResult = browserSwitchClient.completeRequest(intent, pendingRequest)) {
                 is BrowserSwitchFinalResult.Success -> runNotifyCompleteJavaScript(browserSwitchFinalResult.returnUrl)
-                is BrowserSwitchFinalResult.Failure -> runFailureJavaScript(browserSwitchFinalResult.error)
+                is BrowserSwitchFinalResult.Failure -> runErrorJavaScript(
+                    browserSwitchFinalResult.error.message ?: "Browser switch failed"
+                )
                 is BrowserSwitchFinalResult.NoResult -> runCanceledJavaScript()
             }
             isHandlingReturnToApp = false
@@ -212,25 +214,6 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
                     + "  });"
                     + "}"
         )
-    }
-
-    private fun runFailureJavaScript(error: BrowserSwitchException) {
-        val formattedError = """new Error('${error.message}')"""
-        val errorJavascript = String.format(
-            (""
-                + "function notifyFailed() {"
-                + "  window.popupBridge.onComplete(%s, %s);"
-                + "}"
-                + ""
-                + "if (document.readyState === 'complete') {"
-                + "  notifyFailed();"
-                + "} else {"
-                + "  window.addEventListener('load', function () {"
-                + "    notifyFailed();"
-                + "  });"
-                + "}"), formattedError, null
-        )
-        runJavaScriptInWebView(errorJavascript)
     }
 
     private fun runJavaScriptInWebView(script: String) {


### PR DESCRIPTION
Thank you for your contribution to Braintree. 


### Summary of changes

 - Adding a new method to handle browser switch failure case.
 - In case of a browser switch failure, the error from `BrowserSwitchFinalResult.Failure` is wrapped in an `Error` object and sent to `onComplete`.

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 