### PR TITLE
Set isVenmoInstalled on window.popupBridge on client init

### DIFF
--- a/PopupBridge/src/main/java/com/braintreepayments/api/PopupBridgeClient.kt
+++ b/PopupBridge/src/main/java/com/braintreepayments/api/PopupBridgeClient.kt
@@ -89,12 +89,12 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
         webView.addJavascriptInterface(popupBridgeJavascriptInterface, POPUP_BRIDGE_NAME)
 
         with(popupBridgeJavascriptInterface) {
-            venmoInstalled = activity.isVenmoInstalled()
             onOpen = { url -> openUrl(url) }
             onSendMessage = { messageName, data ->
                 messageListener?.onMessageReceived(messageName, data)
             }
         }
+        setVenmoInstalled(activity.isVenmoInstalled())
     }
 
     fun setNavigationListener(listener: PopupBridgeNavigationListener?) {
@@ -211,6 +211,23 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
                     + "} else {"
                     + "  window.addEventListener('load', function () {"
                     + "    notifyCanceled();"
+                    + "  });"
+                    + "}"
+        )
+    }
+
+    private fun setVenmoInstalled(isVenmoInstalled: Boolean) {
+        runJavaScriptInWebView(
+            ""
+                    + "function setVenmoInstalled() {"
+                    + "    window.popupBridge.isVenmoInstalled = ${isVenmoInstalled};"
+                    + "}"
+                    + ""
+                    + "if (document.readyState === 'complete') {"
+                    + "  setVenmoInstalled();"
+                    + "} else {"
+                    + "  window.addEventListener('load', function () {"
+                    + "    setVenmoInstalled();"
                     + "  });"
                     + "}"
         )

--- a/PopupBridge/src/main/java/com/braintreepayments/api/internal/PopupBridgeJavascriptInterface.kt
+++ b/PopupBridge/src/main/java/com/braintreepayments/api/internal/PopupBridgeJavascriptInterface.kt
@@ -12,7 +12,6 @@ internal class PopupBridgeJavascriptInterface(
     private val returnUrlScheme: String,
 ) {
 
-    var venmoInstalled: Boolean = false
     var onOpen: ((url: String?) -> Unit)? = null
     var onSendMessage: ((messageName: String?, data: String?) -> Unit)? = null
 
@@ -23,10 +22,6 @@ internal class PopupBridgeJavascriptInterface(
             returnUrlScheme,
             POPUP_BRIDGE_URL_HOST
         )
-
-    @get:JavascriptInterface
-    val isVenmoInstalled: Boolean
-        get() = venmoInstalled
 
     @JavascriptInterface
     fun open(url: String?) {

--- a/PopupBridge/src/test/java/com/braintreepayments/api/internal/PopupBridgeJavascriptInterfaceUnitTest.kt
+++ b/PopupBridge/src/test/java/com/braintreepayments/api/internal/PopupBridgeJavascriptInterfaceUnitTest.kt
@@ -24,17 +24,6 @@ class PopupBridgeJavascriptInterfaceUnitTest {
     }
 
     @Test
-    fun `getting isVenmoInstalled returns false by default`() {
-        assertFalse(subject.isVenmoInstalled)
-    }
-
-    @Test
-    fun `getting isVenmoInstalled when set to true then returns true`() {
-        subject.venmoInstalled = true
-        assertTrue(subject.isVenmoInstalled)
-    }
-
-    @Test
     fun `when open is invoked, onOpen callback is called with url`() {
         var capturedUrl: String? = null
         subject.onOpen = { url -> capturedUrl = url }


### PR DESCRIPTION
Thank you for your contribution to Braintree. 


### Summary of changes

 - Instead of exposing a `@JavascriptInterface` that the web view needs to call, I'm directly setting `isVenmoInstalled` onto `window.popupBridge` directly. This is how iOS does it today and reduce overhead on how it is done on web.

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 