### PR TITLE
Add Security Workflows

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,23 @@
+name: Security
+
+permissions:
+  contents: write         # Needed by both CodeQL and dependency review
+  pull-requests: write    # Needed by dependency review
+  statuses: write         # Needed by dependency review (to post checks)
+  security-events: write  # Needed by CodeQL to upload SARIF
+  packages: read          # Needed by CodeQL for private/internal packs
+  actions: read           # Needed by CodeQL to access internal actions
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  code-scanning:
+    uses: braintree/security-workflows/.github/workflows/codeql-android.yml@main
+
+  dependency-review:
+    uses: braintree/security-workflows/.github/workflows/dependency-review-gradle.yml@main


### PR DESCRIPTION
Thank you for your contribution to Braintree. 


### Summary of changes

 - All apps and SDKs that interact with any PCI-related data are required to have code scanning. The following PR adds CodeQL (SAST) and dependency-review (SCA) to accomplish this goal.

 ### Checklist

 - [ ] Added a changelog entry

### Authors
- @JLESUS 