### PR TITLE
Add PayPal app-switch support to Popup Bridge

### DIFF
--- a/Demo/src/main/java/com/braintreepayments/popupbridge/demo/PopupActivity.java
+++ b/Demo/src/main/java/com/braintreepayments/popupbridge/demo/PopupActivity.java
@@ -45,6 +45,7 @@ public class PopupActivity extends AppCompatActivity {
     @Override
     protected void onNewIntent(Intent newIntent) {
         super.onNewIntent(newIntent);
+        setIntent(newIntent);
         popupBridgeClient.handleReturnToApp(newIntent);
     }
 

--- a/PopupBridge/src/main/AndroidManifest.xml
+++ b/PopupBridge/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <queries>
+        <package android:name="com.paypal.android.p2pmobile" />
         <package android:name="com.venmo" />
     </queries>
 </manifest>

--- a/PopupBridge/src/main/java/com/braintreepayments/api/PopupBridgeAnalytics.kt
+++ b/PopupBridge/src/main/java/com/braintreepayments/api/PopupBridgeAnalytics.kt
@@ -5,4 +5,8 @@ internal object PopupBridgeAnalytics {
     const val POPUP_BRIDGE_SUCCEEDED = "popup-bridge:succeeded"
     const val POPUP_BRIDGE_FAILED = "popup-bridge:failed"
     const val POPUP_BRIDGE_CANCELED = "popup-bridge:canceled"
+    const val POPUP_BRIDGE_APP_DETECTED = "popup-bridge:app-switch:app-detected"
+    const val POPUP_BRIDGE_APP_LAUNCHED = "popup-bridge:app-switch:app-launched"
+    const val POPUP_BRIDGE_APP_LAUNCH_FAILED = "popup-bridge:app-switch:app-launch-failed"
+    const val POPUP_BRIDGE_APP_SWITCH_RETURNED = "popup-bridge:app-switch:returned"
 }

--- a/PopupBridge/src/main/java/com/braintreepayments/api/PopupBridgeClient.kt
+++ b/PopupBridge/src/main/java/com/braintreepayments/api/PopupBridgeClient.kt
@@ -107,7 +107,7 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
 
         with(popupBridgeJavascriptInterface) {
             onOpen = { url -> openUrl(url) }
-            onLaunchApp = { url -> launchApp(url) }
+            onLaunchApp = { url -> this@PopupBridgeClient.launchApp(url) }
             onSendMessage = { messageName, data ->
                 messageListener?.onMessageReceived(messageName, data)
             }
@@ -168,6 +168,11 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
     }
 
     private fun launchAppOnMainThread(url: String?, activity: ComponentActivity) {
+        if (url.isNullOrBlank()) {
+            errorListener?.onError(IllegalArgumentException("Invalid URL for app launch"))
+            return
+        }
+
         activeInstance = WeakReference(this)
         isHandlingReturnToApp = true
 

--- a/PopupBridge/src/main/java/com/braintreepayments/api/PopupBridgeClient.kt
+++ b/PopupBridge/src/main/java/com/braintreepayments/api/PopupBridgeClient.kt
@@ -1,8 +1,11 @@
 package com.braintreepayments.api
 
 import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
 import android.webkit.WebView
 import androidx.activity.ComponentActivity
 import androidx.core.net.toUri
@@ -15,6 +18,7 @@ import com.braintreepayments.api.internal.AnalyticsParamRepository
 import com.braintreepayments.api.internal.PendingRequestRepository
 import com.braintreepayments.api.internal.PopupBridgeJavascriptInterface
 import com.braintreepayments.api.internal.PopupBridgeJavascriptInterface.Companion.POPUP_BRIDGE_URL_HOST
+import com.braintreepayments.api.internal.isPayPalInstalled
 import java.lang.ref.WeakReference
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -34,10 +38,14 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
         coroutineScope = activity.lifecycleScope,
     ),
     analyticsParamRepository: AnalyticsParamRepository = AnalyticsParamRepository.instance,
-    popupBridgeJavascriptInterface: PopupBridgeJavascriptInterface = PopupBridgeJavascriptInterface(returnUrlScheme),
+    popupBridgeJavascriptInterface: PopupBridgeJavascriptInterface = PopupBridgeJavascriptInterface(
+        returnUrlScheme = returnUrlScheme,
+        context = activity.applicationContext,
+    ),
 ) {
     private val activityRef = WeakReference(activity)
     private val webViewRef = WeakReference(webView)
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     private var navigationListener: PopupBridgeNavigationListener? = null
     private var messageListener: PopupBridgeMessageListener? = null
@@ -93,8 +101,13 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
         webView.addJavascriptInterface(popupBridgeJavascriptInterface, POPUP_BRIDGE_NAME)
         webView.webViewClient = popupBridgeWebViewClient
 
+        if (activity.applicationContext.isPayPalInstalled()) {
+            analyticsClient.sendEvent(PopupBridgeAnalytics.POPUP_BRIDGE_APP_DETECTED)
+        }
+
         with(popupBridgeJavascriptInterface) {
             onOpen = { url -> openUrl(url) }
+            onLaunchApp = { url -> launchApp(url) }
             onSendMessage = { messageName, data ->
                 messageListener?.onMessageReceived(messageName, data)
             }
@@ -114,6 +127,13 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
     }
 
     fun handleReturnToApp(intent: Intent) {
+        // Try app switch return first (deep link from PayPal/Venmo app)
+        val returnUri = intent.data
+        if (returnUri != null && returnUri.host == POPUP_BRIDGE_URL_HOST) {
+            handleAppSwitchReturn(returnUri)
+            return
+        }
+
         if (isHandlingReturnToApp) return
         isHandlingReturnToApp = true
 
@@ -134,6 +154,53 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
                 is BrowserSwitchFinalResult.NoResult -> runCanceledJavaScript()
             }
             isHandlingReturnToApp = false
+        }
+    }
+
+    /**
+     * Entry point when the web page calls window.popupBridge.launchApp(url).
+     * Posts to the main thread so [startActivity] is never called from a background thread
+     * (JavascriptInterface callbacks can be invoked off the main thread).
+     */
+    private fun launchApp(url: String?) {
+        val activity = activityRef.get() as? ComponentActivity ?: return
+        mainHandler.post { launchAppOnMainThread(url, activity) }
+    }
+
+    private fun launchAppOnMainThread(url: String?, activity: ComponentActivity) {
+        activeInstance = WeakReference(this)
+        isHandlingReturnToApp = true
+
+        val uri = url?.toUri() ?: run {
+            errorListener?.onError(IllegalArgumentException("Invalid URL for app launch"))
+            return
+        }
+
+        val intent = Intent(Intent.ACTION_VIEW, uri).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+
+        try {
+            activity.startActivity(intent)
+            analyticsClient.sendEvent(PopupBridgeAnalytics.POPUP_BRIDGE_APP_LAUNCHED)
+        } catch (_: ActivityNotFoundException) {
+            isHandlingReturnToApp = false
+            analyticsClient.sendEvent(PopupBridgeAnalytics.POPUP_BRIDGE_APP_LAUNCH_FAILED)
+            openUrl(url)
+        }
+    }
+
+    private fun handleAppSwitchReturn(returnUri: Uri) {
+        if (!isHandlingReturnToApp) return
+        isHandlingReturnToApp = false
+
+        analyticsClient.sendEvent(PopupBridgeAnalytics.POPUP_BRIDGE_APP_SWITCH_RETURNED)
+
+        val path = returnUri.path.orEmpty()
+        if (path.contains("onCancel")) {
+            runCanceledJavaScript()
+        } else {
+            runNotifyCompleteJavaScript(returnUri)
         }
     }
 
@@ -229,6 +296,9 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
     companion object {
         private const val REQUEST_CODE: Int = 1
         private const val POPUP_BRIDGE_NAME: String = "popupBridge"
+
+        @Volatile
+        private var activeInstance: WeakReference<PopupBridgeClient>? = null
 
         private const val ON_COMPLETE_JAVA_SCRIPT = (""
                 + "function notifyComplete() {"

--- a/PopupBridge/src/main/java/com/braintreepayments/api/PopupBridgeClient.kt
+++ b/PopupBridge/src/main/java/com/braintreepayments/api/PopupBridgeClient.kt
@@ -33,6 +33,7 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
     private val returnUrlScheme: String,
     private val popupBridgeWebViewClient: PopupBridgeWebViewClient,
     private val browserSwitchClient: BrowserSwitchClient,
+    private val enablePopupBridgeAppSwitch: Boolean = false,
     private val pendingRequestRepository: PendingRequestRepository = PendingRequestRepository(activity.applicationContext),
     private val coroutineScope: CoroutineScope = activity.lifecycleScope,
     private val analyticsClient: AnalyticsClient = AnalyticsClient(
@@ -43,6 +44,7 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
     popupBridgeJavascriptInterface: PopupBridgeJavascriptInterface = PopupBridgeJavascriptInterface(
         returnUrlScheme = returnUrlScheme,
         context = activity.applicationContext,
+        enablePopupBridgeAppSwitch = enablePopupBridgeAppSwitch,
     ),
 ) {
     private val activityRef = WeakReference(activity)
@@ -74,6 +76,10 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
      * @param webView The [WebView] to enable for PopupBridge.
      * @param returnUrlScheme The return url scheme to use for deep linking back into the application.
      * @param popupBridgeWebViewClient The [PopupBridgeWebViewClient] to use for handling web view events.
+     * @param enablePopupBridgeAppSwitch When true, allows the SDK to launch the native PayPal app
+     *   for checkout instead of opening a browser. Defaults to false for backward compatibility.
+     *   This is specific to the popup bridge flow and is separate from the JS SDK's
+     *   appSwitchWhenAvailable which controls non-webview mobile browser app switch.
      * @throws IllegalArgumentException If the activity is not valid or the fragment cannot be added.
      */
     @JvmOverloads
@@ -81,13 +87,15 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
         activity: ComponentActivity,
         webView: WebView,
         returnUrlScheme: String,
-        popupBridgeWebViewClient: PopupBridgeWebViewClient = PopupBridgeWebViewClient()
+        popupBridgeWebViewClient: PopupBridgeWebViewClient = PopupBridgeWebViewClient(),
+        enablePopupBridgeAppSwitch: Boolean = false,
     ) : this(
         activity = activity,
         webView = webView,
         returnUrlScheme = returnUrlScheme,
         popupBridgeWebViewClient = popupBridgeWebViewClient,
-        browserSwitchClient = BrowserSwitchClient()
+        browserSwitchClient = BrowserSwitchClient(),
+        enablePopupBridgeAppSwitch = enablePopupBridgeAppSwitch,
     )
 
     init {
@@ -103,7 +111,7 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
         webView.addJavascriptInterface(popupBridgeJavascriptInterface, POPUP_BRIDGE_NAME)
         webView.webViewClient = popupBridgeWebViewClient
 
-        if (activity.applicationContext.isPayPalInstalled()) {
+        if (enablePopupBridgeAppSwitch && activity.applicationContext.isPayPalInstalled()) {
             analyticsClient.sendEvent(PopupBridgeAnalytics.POPUP_BRIDGE_APP_DETECTED)
         }
 

--- a/PopupBridge/src/main/java/com/braintreepayments/api/PopupBridgeClient.kt
+++ b/PopupBridge/src/main/java/com/braintreepayments/api/PopupBridgeClient.kt
@@ -18,14 +18,13 @@ import com.braintreepayments.api.internal.AnalyticsParamRepository
 import com.braintreepayments.api.internal.PendingRequestRepository
 import com.braintreepayments.api.internal.PopupBridgeJavascriptInterface
 import com.braintreepayments.api.internal.PopupBridgeJavascriptInterface.Companion.POPUP_BRIDGE_URL_HOST
+import com.braintreepayments.api.internal.PAYPAL_APP_PACKAGE
 import com.braintreepayments.api.internal.isPayPalInstalled
 import java.lang.ref.WeakReference
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.json.JSONException
 import org.json.JSONObject
-
-private const val PAYPAL_APP_PACKAGE = "com.paypal.android.p2pmobile"
 
 class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal constructor(
     activity: ComponentActivity,
@@ -56,16 +55,21 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
     private var errorListener: PopupBridgeErrorListener? = null
 
     /**
-     * Ensures that [handleReturnToApp] is only called once, even if both `onResume` and `onNewIntent` invoke it.
+     * Browser-switch path only: ensures [handleReturnToApp] completes the pending browser request at most once
+     * when both `onResume` and `onNewIntent` invoke it (singleTop / singleTask / singleInstance).
      *
-     * If the host app's Activity has a launch type of singleTop, singleTask, or singleInstance, [handleReturnToApp]
-     * should be called in both onResume and onNewIntent. This is to cover all cases where the user cancels the flow.
-     *
-     * Since the [PendingRequestRepository] functions are suspend functions, we need to ensure that the
-     * [handleReturnToApp] logic is only invoked once.
+     * Not used for native app-switch returns; see [expectingAppSwitchReturn].
      */
     @Volatile
     private var isHandlingReturnToApp = false
+
+    /**
+     * Set to `true` when [launchApp] starts an app-switch checkout so we only accept the following
+     * popupbridgev1 deep link as that flow's return (ignores stale links). Cleared when
+     * [handleAppSwitchReturn] runs or when launch falls back to the browser.
+     */
+    @Volatile
+    private var expectingAppSwitchReturn = false
 
     /**
      * Create a new instance of [PopupBridgeClient].
@@ -180,18 +184,17 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
         val activity = activityRef.get() as? ComponentActivity ?: run {
             return
         }
-        mainHandler.post { launchAppOnMainThread(url, activity) }
+        mainHandler.post { launchAppAssumingMainThread(url, activity) }
     }
 
-    private fun launchAppOnMainThread(url: String?, activity: ComponentActivity) {
+    private fun launchAppAssumingMainThread(url: String?, activity: ComponentActivity) {
         if (url.isNullOrBlank()) {
             errorListener?.onError(IllegalArgumentException("Invalid URL for app launch"))
             return
         }
 
         clearPopupBridgeReturnIntentIfPresent("launching_new_app_switch")
-        activeInstance = WeakReference(this)
-        isHandlingReturnToApp = true
+        expectingAppSwitchReturn = true
 
         val uri = url?.toUri() ?: run {
             errorListener?.onError(IllegalArgumentException("Invalid URL for app launch"))
@@ -209,7 +212,7 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
             activity.startActivity(intent)
             analyticsClient.sendEvent(PopupBridgeAnalytics.POPUP_BRIDGE_APP_LAUNCHED)
         } catch (_: ActivityNotFoundException) {
-            isHandlingReturnToApp = false
+            expectingAppSwitchReturn = false
             analyticsClient.sendEvent(PopupBridgeAnalytics.POPUP_BRIDGE_APP_LAUNCH_FAILED)
             openUrl(url)
         }
@@ -231,26 +234,40 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
             return true
         }
 
-        val normalizedPath = path.orEmpty().lowercase()
-        return normalizedPath.contains("onapprove") ||
-            normalizedPath.contains("oncancel") ||
-            normalizedPath.contains("onerror") ||
-            normalizedPath.contains("/approve") ||
-            normalizedPath.contains("/cancel") ||
-            normalizedPath.contains("/error")
+        return hasAppSwitchPath()
     }
 
+    private fun Uri.isCancelUri(): Boolean {
+        val normalizedPath = path.orEmpty().lowercase()
+        return normalizedPath.contains("oncancel") ||
+            normalizedPath.contains("/cancel")
+    }
+
+    private fun Uri.hasAppSwitchPath(): Boolean {
+        val normalizedPath = path.orEmpty().lowercase()
+        return normalizedPath.contains("onapprove") ||
+            normalizedPath.contains("onerror") ||
+            normalizedPath.contains("/approve") ||
+            normalizedPath.contains("/error") ||
+            isCancelUri()
+    }
+
+    /**
+     * Handles the return deep link from a native PayPal/Venmo app switch.
+     *
+     * Runs only when [expectingAppSwitchReturn] is true (set by [launchApp] before starting the
+     * native app) so stale popupbridgev1 links do not complete or cancel the wrong session.
+     */
     private fun handleAppSwitchReturn(returnUri: Uri) {
-        if (!isHandlingReturnToApp) {
+        if (!expectingAppSwitchReturn) {
             return
         }
-        isHandlingReturnToApp = false
+        expectingAppSwitchReturn = false
 
         analyticsClient.sendEvent(PopupBridgeAnalytics.POPUP_BRIDGE_APP_SWITCH_RETURNED)
         clearPopupBridgeReturnIntentIfPresent("app_switch_return_consumed")
 
-        val path = returnUri.path.orEmpty()
-        if (path.contains("onCancel")) {
+        if (returnUri.isCancelUri()) {
             runCanceledJavaScript()
         } else {
             runNotifyCompleteJavaScript(returnUri)
@@ -367,9 +384,6 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
     companion object {
         private const val REQUEST_CODE: Int = 1
         private const val POPUP_BRIDGE_NAME: String = "popupBridge"
-
-        @Volatile
-        private var activeInstance: WeakReference<PopupBridgeClient>? = null
 
         private const val ON_COMPLETE_JAVA_SCRIPT = (""
                 + "function notifyComplete() {"

--- a/PopupBridge/src/main/java/com/braintreepayments/api/PopupBridgeClient.kt
+++ b/PopupBridge/src/main/java/com/braintreepayments/api/PopupBridgeClient.kt
@@ -25,6 +25,8 @@ import kotlinx.coroutines.launch
 import org.json.JSONException
 import org.json.JSONObject
 
+private const val PAYPAL_APP_PACKAGE = "com.paypal.android.p2pmobile"
+
 class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal constructor(
     activity: ComponentActivity,
     webView: WebView,
@@ -127,14 +129,17 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
     }
 
     fun handleReturnToApp(intent: Intent) {
-        // Try app switch return first (deep link from PayPal/Venmo app)
+        // Only treat PopupBridge deep links with app-switch-style path/fragment data as
+        // native app returns. Secure-browser fallback can also return to popupbridgev1.
         val returnUri = intent.data
-        if (returnUri != null && returnUri.host == POPUP_BRIDGE_URL_HOST) {
+        if (returnUri != null && returnUri.isAppSwitchReturnUri()) {
             handleAppSwitchReturn(returnUri)
             return
         }
 
-        if (isHandlingReturnToApp) return
+        if (isHandlingReturnToApp) {
+            return
+        }
         isHandlingReturnToApp = true
 
         coroutineScope.launch {
@@ -153,6 +158,7 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
                 )
                 is BrowserSwitchFinalResult.NoResult -> runCanceledJavaScript()
             }
+            clearPopupBridgeReturnIntentIfPresent("browser_switch_result_consumed")
             isHandlingReturnToApp = false
         }
     }
@@ -163,7 +169,9 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
      * (JavascriptInterface callbacks can be invoked off the main thread).
      */
     private fun launchApp(url: String?) {
-        val activity = activityRef.get() as? ComponentActivity ?: return
+        val activity = activityRef.get() as? ComponentActivity ?: run {
+            return
+        }
         mainHandler.post { launchAppOnMainThread(url, activity) }
     }
 
@@ -173,6 +181,7 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
             return
         }
 
+        clearPopupBridgeReturnIntentIfPresent("launching_new_app_switch")
         activeInstance = WeakReference(this)
         isHandlingReturnToApp = true
 
@@ -183,6 +192,9 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
 
         val intent = Intent(Intent.ACTION_VIEW, uri).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            if (uri.isPayPalAppSwitchUri()) {
+                setPackage(PAYPAL_APP_PACKAGE)
+            }
         }
 
         try {
@@ -195,11 +207,39 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
         }
     }
 
+    private fun Uri.isPayPalAppSwitchUri(): Boolean {
+        val normalizedHost = host?.removePrefix("www.")
+        return scheme.equals("https", ignoreCase = true) &&
+            normalizedHost == "paypal.com" &&
+            path.orEmpty().startsWith("/app-switch-checkout")
+    }
+
+    private fun Uri.isAppSwitchReturnUri(): Boolean {
+        if (host != POPUP_BRIDGE_URL_HOST) {
+            return false
+        }
+
+        if (!fragment.isNullOrBlank()) {
+            return true
+        }
+
+        val normalizedPath = path.orEmpty().lowercase()
+        return normalizedPath.contains("onapprove") ||
+            normalizedPath.contains("oncancel") ||
+            normalizedPath.contains("onerror") ||
+            normalizedPath.contains("/approve") ||
+            normalizedPath.contains("/cancel") ||
+            normalizedPath.contains("/error")
+    }
+
     private fun handleAppSwitchReturn(returnUri: Uri) {
-        if (!isHandlingReturnToApp) return
+        if (!isHandlingReturnToApp) {
+            return
+        }
         isHandlingReturnToApp = false
 
         analyticsClient.sendEvent(PopupBridgeAnalytics.POPUP_BRIDGE_APP_SWITCH_RETURNED)
+        clearPopupBridgeReturnIntentIfPresent("app_switch_return_consumed")
 
         val path = returnUri.path.orEmpty()
         if (path.contains("onCancel")) {
@@ -212,7 +252,9 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
     private fun openUrl(url: String?) {
         analyticsClient.sendEvent(PopupBridgeAnalytics.POPUP_BRIDGE_STARTED)
 
-        val activity = activityRef.get() ?: return
+        val activity = activityRef.get() ?: run {
+            return
+        }
         val browserSwitchOptions = BrowserSwitchOptions()
             .requestCode(REQUEST_CODE)
             .url(url?.toUri())
@@ -233,7 +275,9 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
     }
 
     private fun runNotifyCompleteJavaScript(returnUri: Uri) {
-        if (returnUri.host != POPUP_BRIDGE_URL_HOST) return
+        if (returnUri.host != POPUP_BRIDGE_URL_HOST) {
+            return
+        }
 
         val payLoadJson = JSONObject()
         val queryItems = JSONObject()
@@ -290,6 +334,20 @@ class PopupBridgeClient @SuppressLint("SetJavaScriptEnabled") internal construct
                     + "  });"
                     + "}"
         )
+    }
+
+    private fun clearPopupBridgeReturnIntentIfPresent(reason: String) {
+        val activity = activityRef.get() ?: return
+        val currentIntent = activity.intent ?: return
+        val currentData = currentIntent.data ?: return
+
+        if (currentData.host != POPUP_BRIDGE_URL_HOST) {
+            return
+        }
+
+        activity.intent = Intent(currentIntent).apply {
+            data = null
+        }
     }
 
     private fun runJavaScriptInWebView(script: String) {

--- a/PopupBridge/src/main/java/com/braintreepayments/api/PopupBridgeWebViewClient.kt
+++ b/PopupBridge/src/main/java/com/braintreepayments/api/PopupBridgeWebViewClient.kt
@@ -13,7 +13,6 @@ import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.annotation.RequiresApi
-import com.braintreepayments.api.internal.isVenmoInstalled
 
 class PopupBridgeWebViewClient(
     private val delegate: WebViewClient? = null
@@ -21,7 +20,6 @@ class PopupBridgeWebViewClient(
 
     override fun onPageFinished(view: WebView?, url: String?) {
         super.onPageFinished(view, url)
-        setVenmoInstalled(view, view?.context?.isVenmoInstalled() == true)
         delegate?.onPageFinished(view, url)
     }
 
@@ -105,23 +103,6 @@ class PopupBridgeWebViewClient(
     override fun onReceivedLoginRequest(view: WebView?, realm: String?, account: String?, args: String?) {
         delegate?.onReceivedLoginRequest(view, realm, account, args)
             ?: super.onReceivedLoginRequest(view, realm, account, args)
-    }
-
-    private fun setVenmoInstalled(view: WebView?, isVenmoInstalled: Boolean) {
-        runJavaScriptInWebView(view,
-            ""
-                + "function setVenmoInstalled() {"
-                + "    window.popupBridge.isVenmoInstalled = ${isVenmoInstalled};"
-                + "}"
-                + ""
-                + "if (document.readyState === 'complete') {"
-                + "  setVenmoInstalled();"
-                + "} else {"
-                + "  window.addEventListener('load', function () {"
-                + "    setVenmoInstalled();"
-                + "  });"
-                + "}"
-        )
     }
 
     private fun runJavaScriptInWebView(webView: WebView?, script: String) {

--- a/PopupBridge/src/main/java/com/braintreepayments/api/internal/AppInstalledChecks.kt
+++ b/PopupBridge/src/main/java/com/braintreepayments/api/internal/AppInstalledChecks.kt
@@ -2,7 +2,7 @@ package com.braintreepayments.api.internal
 
 import android.content.Context
 
-private const val PAYPAL_APP_PACKAGE = "com.paypal.android.p2pmobile"
+internal const val PAYPAL_APP_PACKAGE = "com.paypal.android.p2pmobile"
 private const val VENMO_APP_PACKAGE = "com.venmo"
 
 fun Context.isPayPalInstalled(): Boolean = AppHelper().isAppInstalled(this, PAYPAL_APP_PACKAGE)

--- a/PopupBridge/src/main/java/com/braintreepayments/api/internal/AppInstalledChecks.kt
+++ b/PopupBridge/src/main/java/com/braintreepayments/api/internal/AppInstalledChecks.kt
@@ -2,6 +2,8 @@ package com.braintreepayments.api.internal
 
 import android.content.Context
 
+private const val PAYPAL_APP_PACKAGE = "com.paypal.android.p2pmobile"
 private const val VENMO_APP_PACKAGE = "com.venmo"
 
+fun Context.isPayPalInstalled(): Boolean = AppHelper().isAppInstalled(this, PAYPAL_APP_PACKAGE)
 fun Context.isVenmoInstalled(): Boolean = AppHelper().isAppInstalled(this, VENMO_APP_PACKAGE)

--- a/PopupBridge/src/main/java/com/braintreepayments/api/internal/PopupBridgeJavascriptInterface.kt
+++ b/PopupBridge/src/main/java/com/braintreepayments/api/internal/PopupBridgeJavascriptInterface.kt
@@ -15,6 +15,7 @@ import android.webkit.JavascriptInterface
 internal class PopupBridgeJavascriptInterface(
     private val returnUrlScheme: String,
     private val context: Context,
+    private val enablePopupBridgeAppSwitch: Boolean = false,
 ) {
 
     var onOpen: ((url: String?) -> Unit)? = null
@@ -24,7 +25,7 @@ internal class PopupBridgeJavascriptInterface(
     /** Exposed to JS as window.popupBridge.isPayPalInstalled. Called by the web page, not by Kotlin. */
     @get:JavascriptInterface
     val isPayPalInstalled: Boolean
-        get() = context.isPayPalInstalled()
+        get() = enablePopupBridgeAppSwitch && context.isPayPalInstalled()
 
     /** Exposed to JS as window.popupBridge.isVenmoInstalled. Called by the web page, not by Kotlin. */
     @get:JavascriptInterface

--- a/PopupBridge/src/main/java/com/braintreepayments/api/internal/PopupBridgeJavascriptInterface.kt
+++ b/PopupBridge/src/main/java/com/braintreepayments/api/internal/PopupBridgeJavascriptInterface.kt
@@ -1,19 +1,35 @@
 package com.braintreepayments.api.internal
 
+import android.content.Context
 import android.webkit.JavascriptInterface
 
 /**
  * `PopupBridgeJavascriptInterface` is a class that provides JavaScript interface methods to a [android.webkit.WebView].
  *
  * The [android.webkit.WebView] should call [android.webkit.WebView.addJavascriptInterface], passing this class as the
- * first argument.
+ * first argument. The web page can then use [window.popupBridge] to access:
+ * - [isPayPalInstalled] / [isVenmoInstalled] — whether the native apps are installed
+ * - [open], [launchApp] — open a URL in browser or native app
+ * - [sendMessage] — send messages to the host
  */
 internal class PopupBridgeJavascriptInterface(
     private val returnUrlScheme: String,
+    private val context: Context,
 ) {
 
     var onOpen: ((url: String?) -> Unit)? = null
+    var onLaunchApp: ((url: String?) -> Unit)? = null
     var onSendMessage: ((messageName: String?, data: String?) -> Unit)? = null
+
+    /** Exposed to JS as window.popupBridge.isPayPalInstalled. Called by the web page, not by Kotlin. */
+    @get:JavascriptInterface
+    val isPayPalInstalled: Boolean
+        get() = context.isPayPalInstalled()
+
+    /** Exposed to JS as window.popupBridge.isVenmoInstalled. Called by the web page, not by Kotlin. */
+    @get:JavascriptInterface
+    val isVenmoInstalled: Boolean
+        get() = context.isVenmoInstalled()
 
     @get:JavascriptInterface
     val returnUrlPrefix: String
@@ -26,6 +42,12 @@ internal class PopupBridgeJavascriptInterface(
     @JavascriptInterface
     fun open(url: String?) {
         onOpen?.invoke(url)
+    }
+
+    /** Exposed to JS as window.popupBridge.launchApp(url). Called by the web page; triggers [onLaunchApp] (wired in PopupBridgeClient to open the URL in the native app or fallback to browser). */
+    @JavascriptInterface
+    fun launchApp(url: String?) {
+        onLaunchApp?.invoke(url)
     }
 
     @JavascriptInterface

--- a/PopupBridge/src/test/java/com/braintreepayments/api/PopupBridgeAnalyticsTest.kt
+++ b/PopupBridge/src/test/java/com/braintreepayments/api/PopupBridgeAnalyticsTest.kt
@@ -1,0 +1,26 @@
+package com.braintreepayments.api
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Tests for [PopupBridgeAnalytics] constants (Popup Bridge++ app-switch events).
+ */
+class PopupBridgeAnalyticsTest {
+
+    @Test
+    fun `app switch analytics constants have expected values`() {
+        assertEquals("popup-bridge:app-switch:app-detected", PopupBridgeAnalytics.POPUP_BRIDGE_APP_DETECTED)
+        assertEquals("popup-bridge:app-switch:app-launched", PopupBridgeAnalytics.POPUP_BRIDGE_APP_LAUNCHED)
+        assertEquals("popup-bridge:app-switch:app-launch-failed", PopupBridgeAnalytics.POPUP_BRIDGE_APP_LAUNCH_FAILED)
+        assertEquals("popup-bridge:app-switch:returned", PopupBridgeAnalytics.POPUP_BRIDGE_APP_SWITCH_RETURNED)
+    }
+
+    @Test
+    fun `existing analytics constants unchanged`() {
+        assertEquals("popup-bridge:started", PopupBridgeAnalytics.POPUP_BRIDGE_STARTED)
+        assertEquals("popup-bridge:succeeded", PopupBridgeAnalytics.POPUP_BRIDGE_SUCCEEDED)
+        assertEquals("popup-bridge:failed", PopupBridgeAnalytics.POPUP_BRIDGE_FAILED)
+        assertEquals("popup-bridge:canceled", PopupBridgeAnalytics.POPUP_BRIDGE_CANCELED)
+    }
+}

--- a/PopupBridge/src/test/java/com/braintreepayments/api/PopupBridgeClientUnitTest.kt
+++ b/PopupBridge/src/test/java/com/braintreepayments/api/PopupBridgeClientUnitTest.kt
@@ -72,6 +72,7 @@ class PopupBridgeClientUnitTest {
     private fun initializeClient(
         activity: ComponentActivity = activityMock,
         webView: WebView = webViewMock,
+        enablePopupBridgeAppSwitch: Boolean = false,
         additionalMocks: () -> Unit = {}
     ) {
         every { webView.post(capture(runnableSlot)) } returns true
@@ -88,6 +89,7 @@ class PopupBridgeClientUnitTest {
             returnUrlScheme = returnUrlScheme,
             popupBridgeWebViewClient = popupBridgeWebViewClient,
             browserSwitchClient = browserSwitchClient,
+            enablePopupBridgeAppSwitch = enablePopupBridgeAppSwitch,
             pendingRequestRepository = pendingRequestRepository,
             coroutineScope = TestScope(testDispatcher),
             analyticsClient = analyticsClient,
@@ -424,7 +426,7 @@ class PopupBridgeClientUnitTest {
         mockkStatic("com.braintreepayments.api.internal.AppInstalledChecksKt")
         every { any<android.content.Context>().isPayPalInstalled() } returns true
 
-        initializeClient()
+        initializeClient(enablePopupBridgeAppSwitch = true)
 
         verify { analyticsClient.sendEvent(POPUP_BRIDGE_APP_DETECTED) }
 
@@ -492,7 +494,7 @@ class PopupBridgeClientUnitTest {
         }
 
     @Test
-    fun `when handleReturnToApp is called with app switch intent and isHandlingReturnToApp path contains onCancel runs canceled JS and sends APP_SWITCH_RETURNED`() =
+    fun `when handleReturnToApp is called with app switch intent and expectingAppSwitchReturn path contains onCancel runs canceled JS and sends APP_SWITCH_RETURNED`() =
         runTest {
             val appSwitchReturnUri = Uri.Builder()
                 .scheme(returnUrlScheme)
@@ -503,7 +505,7 @@ class PopupBridgeClientUnitTest {
 
             initializeClient()
 
-            setPrivateIsHandlingReturnToApp(subject, true)
+            setPrivateExpectingAppSwitchReturn(subject, true)
 
             subject.handleReturnToApp(intent)
             testScheduler.advanceUntilIdle()
@@ -518,7 +520,33 @@ class PopupBridgeClientUnitTest {
         }
 
     @Test
-    fun `when handleReturnToApp is called with app switch intent and isHandlingReturnToApp path not onCancel runs notifyComplete JS and sends APP_SWITCH_RETURNED`() =
+    fun `when handleReturnToApp is called with app switch intent and path is cancel segment runs canceled JS`() =
+        runTest {
+            val appSwitchReturnUri = Uri.Builder()
+                .scheme(returnUrlScheme)
+                .authority(POPUP_BRIDGE_URL_HOST)
+                .path("/some/cancel/flow")
+                .build()
+            every { intent.data } returns appSwitchReturnUri
+
+            initializeClient()
+
+            setPrivateExpectingAppSwitchReturn(subject, true)
+
+            subject.handleReturnToApp(intent)
+            testScheduler.advanceUntilIdle()
+            runnableSlot.captured.run()
+
+            verify { analyticsClient.sendEvent(POPUP_BRIDGE_APP_SWITCH_RETURNED) }
+            verify {
+                webViewMock.evaluateJavascript(withArg { script ->
+                    assertTrue(script.contains("notifyCanceled()"))
+                }, null)
+            }
+        }
+
+    @Test
+    fun `when handleReturnToApp is called with app switch intent and expectingAppSwitchReturn path not onCancel runs notifyComplete JS and sends APP_SWITCH_RETURNED`() =
         runTest {
             val appSwitchReturnUri = Uri.Builder()
                 .scheme(returnUrlScheme)
@@ -530,7 +558,7 @@ class PopupBridgeClientUnitTest {
 
             initializeClient()
 
-            setPrivateIsHandlingReturnToApp(subject, true)
+            setPrivateExpectingAppSwitchReturn(subject, true)
 
             subject.handleReturnToApp(intent)
             testScheduler.advanceUntilIdle()
@@ -559,7 +587,7 @@ class PopupBridgeClientUnitTest {
             every { activityMock.intent = capture(clearedIntentSlot) } returns Unit
 
             initializeClient()
-            setPrivateIsHandlingReturnToApp(subject, true)
+            setPrivateExpectingAppSwitchReturn(subject, true)
 
             subject.handleReturnToApp(intent)
             testScheduler.advanceUntilIdle()
@@ -686,7 +714,7 @@ class PopupBridgeClientUnitTest {
         }
 
     @Test
-    fun `when handleReturnToApp is called with app switch intent but isHandlingReturnToApp false no JS is run`() =
+    fun `when handleReturnToApp is called with app switch intent but expectingAppSwitchReturn false no JS is run`() =
         runTest {
             val appSwitchReturnUri = Uri.Builder()
                 .scheme(returnUrlScheme)
@@ -696,7 +724,7 @@ class PopupBridgeClientUnitTest {
             every { intent.data } returns appSwitchReturnUri
 
             initializeClient()
-            // Do not set isHandlingReturnToApp; handleAppSwitchReturn returns early
+            // Do not set expectingAppSwitchReturn; handleAppSwitchReturn returns early
 
             subject.handleReturnToApp(intent)
             testScheduler.advanceUntilIdle()
@@ -705,8 +733,8 @@ class PopupBridgeClientUnitTest {
             verify(exactly = 0) { webViewMock.evaluateJavascript(any(), any()) }
         }
 
-    private fun setPrivateIsHandlingReturnToApp(client: PopupBridgeClient, value: Boolean) {
-        val field = PopupBridgeClient::class.java.getDeclaredField("isHandlingReturnToApp")
+    private fun setPrivateExpectingAppSwitchReturn(client: PopupBridgeClient, value: Boolean) {
+        val field = PopupBridgeClient::class.java.getDeclaredField("expectingAppSwitchReturn")
         field.isAccessible = true
         field.setBoolean(client, value)
     }

--- a/PopupBridge/src/test/java/com/braintreepayments/api/PopupBridgeClientUnitTest.kt
+++ b/PopupBridge/src/test/java/com/braintreepayments/api/PopupBridgeClientUnitTest.kt
@@ -2,9 +2,14 @@ package com.braintreepayments.api
 
 import android.content.Intent
 import android.net.Uri
+import android.os.Looper
 import android.webkit.WebView
 import androidx.activity.ComponentActivity
 import androidx.core.net.toUri
+import com.braintreepayments.api.PopupBridgeAnalytics.POPUP_BRIDGE_APP_DETECTED
+import com.braintreepayments.api.PopupBridgeAnalytics.POPUP_BRIDGE_APP_LAUNCHED
+import com.braintreepayments.api.PopupBridgeAnalytics.POPUP_BRIDGE_APP_LAUNCH_FAILED
+import com.braintreepayments.api.PopupBridgeAnalytics.POPUP_BRIDGE_APP_SWITCH_RETURNED
 import com.braintreepayments.api.PopupBridgeAnalytics.POPUP_BRIDGE_CANCELED
 import com.braintreepayments.api.PopupBridgeAnalytics.POPUP_BRIDGE_FAILED
 import com.braintreepayments.api.PopupBridgeAnalytics.POPUP_BRIDGE_STARTED
@@ -13,12 +18,16 @@ import com.braintreepayments.api.internal.AnalyticsClient
 import com.braintreepayments.api.internal.AnalyticsParamRepository
 import com.braintreepayments.api.internal.PendingRequestRepository
 import com.braintreepayments.api.internal.PopupBridgeJavascriptInterface
+import com.braintreepayments.api.internal.PopupBridgeJavascriptInterface.Companion.POPUP_BRIDGE_URL_HOST
+import com.braintreepayments.api.internal.isPayPalInstalled
 import com.braintreepayments.api.util.CoroutineTestRule
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.slot
+import io.mockk.unmockkAll
 import io.mockk.verify
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
@@ -30,6 +39,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
 
 @RunWith(RobolectricTestRunner::class)
 class PopupBridgeClientUnitTest {
@@ -56,6 +66,7 @@ class PopupBridgeClientUnitTest {
     private val intent: Intent = mockk(relaxed = true)
     private val runnableSlot = slot<Runnable>()
     private val onOpenSlot = slot<(String?) -> Unit>()
+    private val onLaunchAppSlot = slot<(String?) -> Unit>()
     private val onSendMessageSlot = slot<(String?, String?) -> Unit>()
 
     private fun initializeClient(
@@ -66,6 +77,7 @@ class PopupBridgeClientUnitTest {
         every { webView.post(capture(runnableSlot)) } returns true
         coEvery { pendingRequestRepository.getPendingRequest() } returns pendingRequest
         every { popupBridgeJavascriptInterface.onOpen = capture(onOpenSlot) } returns Unit
+        every { popupBridgeJavascriptInterface.onLaunchApp = capture(onLaunchAppSlot) } returns Unit
         every { popupBridgeJavascriptInterface.onSendMessage = capture(onSendMessageSlot) } returns Unit
 
         additionalMocks()
@@ -404,6 +416,212 @@ class PopupBridgeClientUnitTest {
 
         verify { messageListener.onMessageReceived(messageName, null) }
     }
+
+    // region App switch / launchApp tests
+
+    @Test
+    fun `on init when PayPal is installed POPUP_BRIDGE_APP_DETECTED is sent`() {
+        mockkStatic("com.braintreepayments.api.internal.AppInstalledChecksKt")
+        every { any<android.content.Context>().isPayPalInstalled() } returns true
+
+        initializeClient()
+
+        verify { analyticsClient.sendEvent(POPUP_BRIDGE_APP_DETECTED) }
+
+        unmockkAll()
+    }
+
+    @Test
+    fun `on init onLaunchApp callback is wired`() {
+        initializeClient()
+
+        // Invoking the callback runs launchApp (posts to main handler); no throw
+        onLaunchAppSlot.captured.invoke("https://www.paypal.com/checkout")
+    }
+
+    @Test
+    fun `when handleReturnToApp is called with app switch intent data host popupbridgev1 browser switch path is not used`() =
+        runTest {
+            val appSwitchReturnUri = Uri.Builder()
+                .scheme(returnUrlScheme)
+                .authority(POPUP_BRIDGE_URL_HOST)
+                .path("/some/path")
+                .build()
+            every { intent.data } returns appSwitchReturnUri
+
+            initializeClient()
+
+            subject.handleReturnToApp(intent)
+            testScheduler.advanceUntilIdle()
+
+            coVerify(exactly = 0) { pendingRequestRepository.getPendingRequest() }
+            verify(exactly = 0) { browserSwitchClient.completeRequest(any(), any()) }
+        }
+
+    @Test
+    fun `when handleReturnToApp is called with app switch intent and isHandlingReturnToApp path contains onCancel runs canceled JS and sends APP_SWITCH_RETURNED`() =
+        runTest {
+            val appSwitchReturnUri = Uri.Builder()
+                .scheme(returnUrlScheme)
+                .authority(POPUP_BRIDGE_URL_HOST)
+                .path("/onCancel")
+                .build()
+            every { intent.data } returns appSwitchReturnUri
+
+            initializeClient()
+
+            setPrivateIsHandlingReturnToApp(subject, true)
+
+            subject.handleReturnToApp(intent)
+            testScheduler.advanceUntilIdle()
+            runnableSlot.captured.run()
+
+            verify { analyticsClient.sendEvent(POPUP_BRIDGE_APP_SWITCH_RETURNED) }
+            verify {
+                webViewMock.evaluateJavascript(withArg { script ->
+                    assertTrue(script.contains("notifyCanceled()") && script.contains("onCancel"))
+                }, null)
+            }
+        }
+
+    @Test
+    fun `when handleReturnToApp is called with app switch intent and isHandlingReturnToApp path not onCancel runs notifyComplete JS and sends APP_SWITCH_RETURNED`() =
+        runTest {
+            val appSwitchReturnUri = Uri.Builder()
+                .scheme(returnUrlScheme)
+                .authority(POPUP_BRIDGE_URL_HOST)
+                .path("/approve")
+                .appendQueryParameter("token", "abc")
+                .build()
+            every { intent.data } returns appSwitchReturnUri
+
+            initializeClient()
+
+            setPrivateIsHandlingReturnToApp(subject, true)
+
+            subject.handleReturnToApp(intent)
+            testScheduler.advanceUntilIdle()
+            runnableSlot.captured.run()
+
+            verify { analyticsClient.sendEvent(POPUP_BRIDGE_APP_SWITCH_RETURNED) }
+            verify {
+                webViewMock.evaluateJavascript(withArg { script ->
+                    assertTrue(script.contains("notifyComplete()") && script.contains("onComplete"))
+                }, null)
+            }
+        }
+
+    @Test
+    fun `when onLaunchApp is invoked with valid url and main handler runs startActivity is called and APP_LAUNCHED is sent`() {
+        initializeClient()
+
+        onLaunchAppSlot.captured.invoke("https://www.paypal.com/checkout")
+
+        // Run the runnable posted to the main handler (launchAppOnMainThread)
+        Shadows.shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+        verify { activityMock.startActivity(any()) }
+        verify { analyticsClient.sendEvent(POPUP_BRIDGE_APP_LAUNCHED) }
+    }
+
+    @Test
+    fun `when onLaunchApp is invoked and startActivity throws ActivityNotFoundException APP_LAUNCH_FAILED is sent and openUrl is called`() =
+        runTest {
+            initializeClient()
+            every { activityMock.startActivity(any()) } throws android.content.ActivityNotFoundException()
+
+            onLaunchAppSlot.captured.invoke("https://www.paypal.com/checkout")
+            Shadows.shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+            testScheduler.advanceUntilIdle()
+
+            verify { analyticsClient.sendEvent(POPUP_BRIDGE_APP_LAUNCH_FAILED) }
+            verify { browserSwitchClient.start(activityMock, any()) }
+        }
+
+    @Test
+    fun `when onLaunchApp is invoked with blank url errorListener is called and no startActivity`() {
+        val errorListener: PopupBridgeErrorListener = mockk(relaxed = true)
+        initializeClient()
+        subject.setErrorListener(errorListener)
+
+        onLaunchAppSlot.captured.invoke("   ")
+        Shadows.shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+        verify { errorListener.onError(any()) }
+        verify(exactly = 0) { activityMock.startActivity(any()) }
+    }
+
+    @Test
+    fun `when onLaunchApp is invoked with null url errorListener is called and no startActivity`() {
+        val errorListener: PopupBridgeErrorListener = mockk(relaxed = true)
+        initializeClient()
+        subject.setErrorListener(errorListener)
+
+        onLaunchAppSlot.captured.invoke(null)
+        Shadows.shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+        verify { errorListener.onError(any()) }
+        verify(exactly = 0) { activityMock.startActivity(any()) }
+    }
+
+    @Test
+    fun `when handleReturnToApp is called with intent data null browser switch path is used`() =
+        runTest {
+            every { intent.data } returns null
+
+            initializeClient()
+
+            subject.handleReturnToApp(intent)
+            testScheduler.advanceUntilIdle()
+
+            coVerify(atLeast = 1) { pendingRequestRepository.getPendingRequest() }
+        }
+
+    @Test
+    fun `when handleReturnToApp is called with intent data host not popupbridgev1 browser switch path is used`() =
+        runTest {
+            val otherHostUri = Uri.Builder()
+                .scheme(returnUrlScheme)
+                .authority("other-host")
+                .path("/path")
+                .build()
+            every { intent.data } returns otherHostUri
+
+            initializeClient()
+
+            subject.handleReturnToApp(intent)
+            testScheduler.advanceUntilIdle()
+
+            coVerify(atLeast = 1) { pendingRequestRepository.getPendingRequest() }
+        }
+
+    @Test
+    fun `when handleReturnToApp is called with app switch intent but isHandlingReturnToApp false no JS is run`() =
+        runTest {
+            val appSwitchReturnUri = Uri.Builder()
+                .scheme(returnUrlScheme)
+                .authority(POPUP_BRIDGE_URL_HOST)
+                .path("/approve")
+                .build()
+            every { intent.data } returns appSwitchReturnUri
+
+            initializeClient()
+            // Do not set isHandlingReturnToApp; handleAppSwitchReturn returns early
+
+            subject.handleReturnToApp(intent)
+            testScheduler.advanceUntilIdle()
+
+            verify(exactly = 0) { analyticsClient.sendEvent(POPUP_BRIDGE_APP_SWITCH_RETURNED) }
+            verify(exactly = 0) { webViewMock.evaluateJavascript(any(), any()) }
+        }
+
+    private fun setPrivateIsHandlingReturnToApp(client: PopupBridgeClient, value: Boolean) {
+        val field = PopupBridgeClient::class.java.getDeclaredField("isHandlingReturnToApp")
+        field.isAccessible = true
+        field.setBoolean(client, value)
+    }
+
+    // endregion
 
     private fun getExpectedSuccessJavascript(error: String?, payload: JSONObject): String {
         return String.format(

--- a/PopupBridge/src/test/java/com/braintreepayments/api/PopupBridgeClientUnitTest.kt
+++ b/PopupBridge/src/test/java/com/braintreepayments/api/PopupBridgeClientUnitTest.kt
@@ -440,12 +440,12 @@ class PopupBridgeClientUnitTest {
     }
 
     @Test
-    fun `when handleReturnToApp is called with app switch intent data host popupbridgev1 browser switch path is not used`() =
+    fun `when handleReturnToApp is called with app switch intent path browser switch path is not used`() =
         runTest {
             val appSwitchReturnUri = Uri.Builder()
                 .scheme(returnUrlScheme)
                 .authority(POPUP_BRIDGE_URL_HOST)
-                .path("/some/path")
+                .path("/onApprove")
                 .build()
             every { intent.data } returns appSwitchReturnUri
 
@@ -456,6 +456,39 @@ class PopupBridgeClientUnitTest {
 
             coVerify(exactly = 0) { pendingRequestRepository.getPendingRequest() }
             verify(exactly = 0) { browserSwitchClient.completeRequest(any(), any()) }
+        }
+
+    @Test
+    fun `when handleReturnToApp is called with popup bridge host and query params browser switch path is used`() =
+        runTest {
+            val browserSwitchReturnUri = Uri.Builder()
+                .scheme(returnUrlScheme)
+                .authority(POPUP_BRIDGE_URL_HOST)
+                .appendQueryParameter("token", "7GJ8435627393170V")
+                .appendQueryParameter("PayerID", "7WSWGN7G2SP2Y")
+                .appendQueryParameter("opType", "payment")
+                .appendQueryParameter("paymentId", "7GJ8435627393170V")
+                .build()
+            val browserSwitchFinalResult = mockk<BrowserSwitchFinalResult.Success>()
+            every { intent.data } returns browserSwitchReturnUri
+            every { browserSwitchClient.completeRequest(intent, pendingRequest) } returns browserSwitchFinalResult
+            every { browserSwitchFinalResult.returnUrl } returns browserSwitchReturnUri
+
+            initializeClient()
+
+            subject.handleReturnToApp(intent)
+            testScheduler.advanceUntilIdle()
+            runnableSlot.captured.run()
+
+            coVerify(atLeast = 1) { pendingRequestRepository.getPendingRequest() }
+            verify { browserSwitchClient.completeRequest(intent, pendingRequest) }
+            verify(exactly = 0) { analyticsClient.sendEvent(POPUP_BRIDGE_APP_SWITCH_RETURNED) }
+            verify {
+                webViewMock.evaluateJavascript(withArg { script ->
+                    assertTrue(script.contains("\"opType\":\"payment\""))
+                    assertTrue(script.contains("\"PayerID\":\"7WSWGN7G2SP2Y\""))
+                }, null)
+            }
         }
 
     @Test
@@ -490,7 +523,7 @@ class PopupBridgeClientUnitTest {
             val appSwitchReturnUri = Uri.Builder()
                 .scheme(returnUrlScheme)
                 .authority(POPUP_BRIDGE_URL_HOST)
-                .path("/approve")
+                .path("/onApprove")
                 .appendQueryParameter("token", "abc")
                 .build()
             every { intent.data } returns appSwitchReturnUri
@@ -512,6 +545,29 @@ class PopupBridgeClientUnitTest {
         }
 
     @Test
+    fun `when handleReturnToApp consumes app switch return, the activity intent data is cleared`() =
+        runTest {
+            val appSwitchReturnUri = Uri.Builder()
+                .scheme(returnUrlScheme)
+                .authority(POPUP_BRIDGE_URL_HOST)
+                .path("/onApprove")
+                .build()
+            val clearedIntentSlot = slot<Intent>()
+
+            every { intent.data } returns appSwitchReturnUri
+            every { activityMock.intent } returns Intent(Intent.ACTION_VIEW, appSwitchReturnUri)
+            every { activityMock.intent = capture(clearedIntentSlot) } returns Unit
+
+            initializeClient()
+            setPrivateIsHandlingReturnToApp(subject, true)
+
+            subject.handleReturnToApp(intent)
+            testScheduler.advanceUntilIdle()
+
+            assertEquals(null, clearedIntentSlot.captured.data)
+        }
+
+    @Test
     fun `when onLaunchApp is invoked with valid url and main handler runs startActivity is called and APP_LAUNCHED is sent`() {
         initializeClient()
 
@@ -522,6 +578,40 @@ class PopupBridgeClientUnitTest {
 
         verify { activityMock.startActivity(any()) }
         verify { analyticsClient.sendEvent(POPUP_BRIDGE_APP_LAUNCHED) }
+    }
+
+    @Test
+    fun `when onLaunchApp is invoked with PayPal app switch url the intent is pinned to the PayPal app package`() {
+        val launchedIntent = slot<Intent>()
+        every { activityMock.startActivity(capture(launchedIntent)) } returns Unit
+
+        initializeClient()
+
+        onLaunchAppSlot.captured.invoke("https://www.paypal.com/app-switch-checkout?token=EC-123")
+        Shadows.shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+        assertEquals("com.paypal.android.p2pmobile", launchedIntent.captured.`package`)
+    }
+
+    @Test
+    fun `when onLaunchApp is invoked with stale popup bridge intent, activity intent data is cleared before launch`() {
+        val staleReturnUri = Uri.Builder()
+            .scheme(returnUrlScheme)
+            .authority(POPUP_BRIDGE_URL_HOST)
+            .path("/onApprove")
+            .build()
+        val clearedIntentSlot = slot<Intent>()
+
+        every { activityMock.intent } returns Intent(Intent.ACTION_VIEW, staleReturnUri)
+        every { activityMock.intent = capture(clearedIntentSlot) } returns Unit
+
+        initializeClient()
+
+        onLaunchAppSlot.captured.invoke("https://www.paypal.com/checkout")
+        Shadows.shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+        assertEquals(null, clearedIntentSlot.captured.data)
+        verify { activityMock.startActivity(any()) }
     }
 
     @Test

--- a/PopupBridge/src/test/java/com/braintreepayments/api/PopupBridgeWebViewClientTest.kt
+++ b/PopupBridge/src/test/java/com/braintreepayments/api/PopupBridgeWebViewClientTest.kt
@@ -1,16 +1,10 @@
 package com.braintreepayments.api
 
 import android.webkit.WebView
-import com.braintreepayments.api.internal.isVenmoInstalled
-import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
 import io.mockk.verify
-import junit.framework.TestCase.assertEquals
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
@@ -22,59 +16,14 @@ class PopupBridgeWebViewClientTest {
 
     @BeforeTest
     fun setup() {
-        mockkStatic("com.braintreepayments.api.internal.AppInstalledChecksKt")
-
-        every { webView.post(any()) } answers {
-            val runnable = firstArg<Runnable>()
-            runnable.run()
-            true
-        }
     }
 
     @Test
-    fun `on init, when venmo installed, isVenmoInstalled is set to true on the popupBridgeJavascriptInterface`() = runTest {
-        every { webView.context.isVenmoInstalled() } returns true
-
+    fun `onPageFinished calls super and does not inject Venmo state`() {
         sut.onPageFinished(webView, "https://example.com")
 
-        verify {
-            webView.evaluateJavascript(withArg { javascriptString ->
-                assertEquals(getExpectedVenmoInstalledJavascript(true), javascriptString)
-            }, null)
-        }
-
-        unmockkAll()
-    }
-
-    @Test
-    fun `on init, when venmo is not installed, isVenmoInstalled is set to false on the popupBridgeJavascriptInterface`() = runTest {
-        every { webView.context.isVenmoInstalled() } returns false
-
-        sut.onPageFinished(webView, "https://example.com")
-
-        verify {
-            webView.evaluateJavascript(withArg { javascriptString ->
-                assertEquals(getExpectedVenmoInstalledJavascript(false), javascriptString)
-            }, null)
-        }
-
-        unmockkAll()
-    }
-
-    private fun getExpectedVenmoInstalledJavascript(isVenmoInstalled: Boolean): String {
-        return String.format(
-            (""
-                + "function setVenmoInstalled() {"
-                + "    window.popupBridge.isVenmoInstalled = %s;"
-                + "}"
-                + ""
-                + "if (document.readyState === 'complete') {"
-                + "  setVenmoInstalled();"
-                + "} else {"
-                + "  window.addEventListener('load', function () {"
-                + "    setVenmoInstalled();"
-                + "  });"
-                + "}"), isVenmoInstalled
-        )
+        // Venmo/PayPal installed state is now exposed via @JavascriptInterface on PopupBridgeJavascriptInterface;
+        // no JavaScript is injected in onPageFinished.
+        verify(exactly = 0) { webView.evaluateJavascript(any(), any()) }
     }
 }

--- a/PopupBridge/src/test/java/com/braintreepayments/api/PopupBridgeWebViewClientTest.kt
+++ b/PopupBridge/src/test/java/com/braintreepayments/api/PopupBridgeWebViewClientTest.kt
@@ -19,11 +19,9 @@ class PopupBridgeWebViewClientTest {
     }
 
     @Test
-    fun `onPageFinished calls super and does not inject Venmo state`() {
+    fun `onPageFinished calls super and does not inject installed state`() {
         sut.onPageFinished(webView, "https://example.com")
 
-        // Venmo/PayPal installed state is now exposed via @JavascriptInterface on PopupBridgeJavascriptInterface;
-        // no JavaScript is injected in onPageFinished.
         verify(exactly = 0) { webView.evaluateJavascript(any(), any()) }
     }
 }

--- a/PopupBridge/src/test/java/com/braintreepayments/api/internal/AppInstalledChecksTest.kt
+++ b/PopupBridge/src/test/java/com/braintreepayments/api/internal/AppInstalledChecksTest.kt
@@ -1,0 +1,60 @@
+package com.braintreepayments.api.internal
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for [isPayPalInstalled] and [isVenmoInstalled] extensions (Popup Bridge++ app detection).
+ */
+class AppInstalledChecksTest {
+
+    @Test
+    fun `isPayPalInstalled returns true when PayPal app is installed`() {
+        val mockContext = mockk<Context>()
+        val mockPackageManager = mockk<PackageManager>()
+        every { mockContext.packageManager } returns mockPackageManager
+        every {
+            mockPackageManager.getApplicationInfo("com.paypal.android.p2pmobile", 0)
+        } returns mockk<ApplicationInfo>()
+
+        assertTrue(mockContext.isPayPalInstalled())
+    }
+
+    @Test
+    fun `isPayPalInstalled returns false when PayPal app is not installed`() {
+        val mockContext = mockk<Context>()
+        val mockPackageManager = mockk<PackageManager>()
+        every { mockContext.packageManager } returns mockPackageManager
+        every {
+            mockPackageManager.getApplicationInfo("com.paypal.android.p2pmobile", 0)
+        } throws PackageManager.NameNotFoundException()
+
+        assertFalse(mockContext.isPayPalInstalled())
+    }
+
+    @Test
+    fun `isVenmoInstalled returns true when Venmo app is installed`() {
+        val mockContext = mockk<Context>()
+        val mockPackageManager = mockk<PackageManager>()
+        every { mockContext.packageManager } returns mockPackageManager
+        every { mockPackageManager.getApplicationInfo("com.venmo", 0) } returns mockk<ApplicationInfo>()
+
+        assertTrue(mockContext.isVenmoInstalled())
+    }
+
+    @Test
+    fun `isVenmoInstalled returns false when Venmo app is not installed`() {
+        val mockContext = mockk<Context>()
+        val mockPackageManager = mockk<PackageManager>()
+        every { mockContext.packageManager } returns mockPackageManager
+        every { mockPackageManager.getApplicationInfo("com.venmo", 0) } throws PackageManager.NameNotFoundException()
+
+        assertFalse(mockContext.isVenmoInstalled())
+    }
+}

--- a/PopupBridge/src/test/java/com/braintreepayments/api/internal/PopupBridgeJavascriptInterfaceUnitTest.kt
+++ b/PopupBridge/src/test/java/com/braintreepayments/api/internal/PopupBridgeJavascriptInterfaceUnitTest.kt
@@ -1,20 +1,22 @@
 package com.braintreepayments.api.internal
 
+import android.content.Context
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import io.mockk.mockk
 
 class PopupBridgeJavascriptInterfaceUnitTest {
 
     private lateinit var subject: PopupBridgeJavascriptInterface
     private val returnUrlScheme = "test-scheme"
+    private val mockContext = mockk<Context>(relaxed = true)
 
     @Before
     fun setup() {
-        subject = PopupBridgeJavascriptInterface(returnUrlScheme)
+        subject = PopupBridgeJavascriptInterface(returnUrlScheme, mockContext)
     }
 
     @Test
@@ -65,5 +67,40 @@ class PopupBridgeJavascriptInterfaceUnitTest {
 
         assertEquals(testMessageName, capturedMessageName)
         assertEquals(testData, capturedData)
+    }
+
+    @Test
+    fun `isPayPalInstalled is exposed to JS and returns boolean from context`() {
+        // When the web page reads window.popupBridge.isPayPalInstalled, this getter runs.
+        val result = subject.isPayPalInstalled
+        assertTrue(result == true || result == false)
+    }
+
+    @Test
+    fun `isVenmoInstalled is exposed to JS and returns boolean from context`() {
+        // When the web page reads window.popupBridge.isVenmoInstalled, this getter runs.
+        val result = subject.isVenmoInstalled
+        assertTrue(result == true || result == false)
+    }
+
+    @Test
+    fun `when launchApp is invoked, onLaunchApp callback is called with url`() {
+        var capturedUrl: String? = null
+        subject.onLaunchApp = { url -> capturedUrl = url }
+
+        val testUrl = "https://www.paypal.com/some/checkout"
+        subject.launchApp(testUrl)
+
+        assertEquals(testUrl, capturedUrl)
+    }
+
+    @Test
+    fun `when launchApp is invoked with null, onLaunchApp callback is called with null`() {
+        var capturedUrl: String? = "not-null"
+        subject.onLaunchApp = { url -> capturedUrl = url }
+
+        subject.launchApp(null)
+
+        assertNull(capturedUrl)
     }
 }


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

### Summary of changes

## Popup Bridge++ Android – App Switch & Analytics

### Overview
This PR adds app-switch support and related analytics to the Popup Bridge Android SDK so that when the PayPal (or Venmo) app is installed, the WebView flow can open the native app and handle the return via deep link. The existing browser-based flow is unchanged. App switch is controlled by the `enablePopupBridgeAppSwitch` parameter (defaults to `false`).

---

### Changes

#### Library – Core Behavior

| File | Change |
|------|--------|
| **AndroidManifest.xml** | Added `<queries>` for `com.paypal.android.p2pmobile` and `com.venmo` (Android 11+ package visibility). |
| **PopupBridgeAnalytics.kt** | Added 4 new app-switch analytics events: `APP_DETECTED`, `APP_LAUNCHED`, `APP_LAUNCH_FAILED`, `APP_SWITCH_RETURNED`. |
| **AppInstalledChecks.kt** | Added `Context.isPayPalInstalled()` extension (same pattern as `isVenmoInstalled()`). |
| **PopupBridgeJavascriptInterface.kt** | Added `Context` and `enablePopupBridgeAppSwitch` to constructor; exposed `isPayPalInstalled`, `isVenmoInstalled`, and `launchApp(url)` to JS. `isPayPalInstalled` only returns `true` when app switch is enabled. |
| **PopupBridgeWebViewClient.kt** | Removed `setVenmoInstalled()` injection in `onPageFinished`; installed state is now exposed via the JS interface only. |
| **PopupBridgeClient.kt** | See details below. |

**PopupBridgeClient.kt details:**
- **Enable/disable app switch:** New `enablePopupBridgeAppSwitch: Boolean = false` parameter on both the internal and public constructors. Passed through to the JS interface. When enabled, `isPayPalInstalled` returns the actual installed state to JS and `APP_DETECTED` analytics fires at init. When disabled (default), app switch is not available and the existing browser flow is used.
- **App switch:** `launchApp(url)` posts to main thread via `mainHandler`, then `launchAppOnMainThread` builds an `ACTION_VIEW` intent. For PayPal app-switch URLs (`paypal.com/app-switch-checkout*`), the intent is pinned to the PayPal package via `setPackage()`. On `ActivityNotFoundException`, sends `APP_LAUNCH_FAILED` and falls back to `openUrl`.
- **Return handling:** `handleReturnToApp` uses `Uri.isAppSwitchReturnUri()` to distinguish app-switch returns (paths like `onApprove`, `onCancel`, `onError`, `/approve`, `/cancel`, `/error`, or non-empty fragments) from browser-switch returns (query-only, no app-switch path). App-switch returns are handled via `handleAppSwitchReturn`; browser-switch returns fall through to the existing `BrowserSwitchClient` logic.
- **Stale intent cleanup:** `clearPopupBridgeReturnIntentIfPresent()` clears `activity.intent.data` after consuming a popupbridge return, preventing stale intents from being reprocessed on `onResume`. Called after app-switch return, browser-switch completion, and before launching a new app switch.
- **Init:** When app switch is enabled and PayPal is installed, sends `POPUP_BRIDGE_APP_DETECTED`; wires `onLaunchApp`; passes `applicationContext` and `enablePopupBridgeAppSwitch` into the JS interface.
- **Robustness:** Null/blank URL and invalid URI in `launchAppOnMainThread` are rejected and reported via `errorListener`.
- **Companion:** `activeInstance` (`WeakReference`) added for app-switch return handling.

#### Demo App

| File | Change |
|------|--------|
| **PopupActivity.java** | Added `setIntent(newIntent)` in `onNewIntent` so `getIntent()` reflects the deep-link intent. |

#### Tests

| File | Change |
|------|--------|
| **AppInstalledChecksTest.kt** *(new)* | `isPayPalInstalled` / `isVenmoInstalled` – installed and not-installed cases. |
| **PopupBridgeAnalyticsTest.kt** *(new)* | Asserts all 8 analytics constants (4 existing + 4 new). |
| **PopupBridgeClientUnitTest.kt** | App-switch and `launchApp` flows: init analytics, callback wiring, return handling (cancel/approve), success/failure/fallback, null/blank URL, main-thread posting, PayPal package pinning, stale intent cleanup, browser-switch vs app-switch URI disambiguation. |
| **PopupBridgeJavascriptInterfaceUnitTest.kt** | Updated constructor with `Context`; added tests for `isPayPalInstalled`, `isVenmoInstalled`, `launchApp` (valid and null). |
| **PopupBridgeWebViewClientTest.kt** | Removed old Venmo-injection tests; asserts `onPageFinished` does not inject JS. |

---

### Enable/Disable App Switch

The `enablePopupBridgeAppSwitch` parameter (defaults to `false`) controls whether app switch is available:

| When disabled (`false`, default) | When enabled (`true`) |
|----------------------------------|-----------------------|
| `isPayPalInstalled` returns `false` to JS | `isPayPalInstalled` returns the actual installed state |
| `APP_DETECTED` analytics not sent at init | `APP_DETECTED` sent if PayPal app is installed |
| `launchApp(url)` still callable but JS won't trigger it (since `isPayPalInstalled` is `false`) | Full app-switch flow enabled |

This is specific to the popup bridge flow and is separate from the JS SDK's `appSwitchWhenAvailable` which controls non-webview mobile browser app switch.

---

### Merchant Impact
- **New optional parameter:** `enablePopupBridgeAppSwitch` on `PopupBridgeClient` constructor (defaults to `false`). Merchants opt in by passing `true`.
- Merchants still call `handleReturnToApp(intent)` from `onNewIntent` (and optionally `onResume`).
- They must call `setIntent(newIntent)` in `onNewIntent` (existing requirement, unchanged).

### Testing
- [x] `./gradlew :PopupBridge:testDebugUnitTest` – all unit tests pass

### Checklist
- [ ] Added a changelog entry

### Authors
- @srdodda