### PR TITLE
feat: add support for android 17

### DIFF
--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -35,12 +35,9 @@ jobs:
           arch: x86_64
           profile: pixel_7_pro
           emulator-options: ${{ env.EMULATOR_OPTIONS }}
-          emulator-boot-timeout: 900
           disk-size: 8G
           script: |
-            adb wait-for-device
-            printf '_ --disable-fre --no-default-browser-check --no-first-run\n' > chrome-command-line
-            adb push chrome-command-line /data/local/tmp/chrome-command-line
+            adb shell 'echo "_ --disable-fre --no-default-browser-check --no-first-run" > /data/local/tmp/chrome-command-line'
             adb shell chmod 777 /data/local/tmp/chrome-command-line
             ./gradlew :Demo:connectedCheck --stacktrace
 
@@ -53,11 +50,8 @@ jobs:
           arch: x86_64
           profile: pixel_7_pro
           emulator-options: ${{ env.EMULATOR_OPTIONS }}
-          emulator-boot-timeout: 900
           disk-size: 8G
           script: |
-            adb wait-for-device
-            printf '_ --disable-fre --no-default-browser-check --no-first-run\n' > chrome-command-line
-            adb push chrome-command-line /data/local/tmp/chrome-command-line
+            adb shell 'echo "_ --disable-fre --no-default-browser-check --no-first-run" > /data/local/tmp/chrome-command-line'
             adb shell chmod 777 /data/local/tmp/chrome-command-line
             ./gradlew :Demo:connectedCheck --stacktrace

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -14,7 +14,7 @@ jobs:
           - api-level: 35
             target: google_apis
           - api-level: "37.0"
-            target: google_apis_ps16k
+            target: playstore_ps16k
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -14,7 +14,7 @@ jobs:
           - api-level: 35
             target: google_apis
           - api-level: "37.0"
-            target: playstore_ps16k
+            target: google_apis_ps16k
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -37,7 +37,9 @@ jobs:
           emulator-options: ${{ env.EMULATOR_OPTIONS }}
           emulator-boot-timeout: 900
           script: |
-            adb shell 'echo "_ --disable-fre --no-default-browser-check --no-first-run" > /data/local/tmp/chrome-command-line'
+            adb wait-for-device
+            printf '_ --disable-fre --no-default-browser-check --no-first-run\n' > chrome-command-line
+            adb push chrome-command-line /data/local/tmp/chrome-command-line
             adb shell chmod 777 /data/local/tmp/chrome-command-line
             ./gradlew :Demo:connectedCheck --stacktrace
 
@@ -52,6 +54,8 @@ jobs:
           emulator-options: ${{ env.EMULATOR_OPTIONS }}
           emulator-boot-timeout: 900
           script: |
-            adb shell 'echo "_ --disable-fre --no-default-browser-check --no-first-run" > /data/local/tmp/chrome-command-line'
+            adb wait-for-device
+            printf '_ --disable-fre --no-default-browser-check --no-first-run\n' > chrome-command-line
+            adb push chrome-command-line /data/local/tmp/chrome-command-line
             adb shell chmod 777 /data/local/tmp/chrome-command-line
             ./gradlew :Demo:connectedCheck --stacktrace

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -3,11 +3,18 @@ on: [pull_request, workflow_dispatch]
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      EMULATOR_OPTIONS: -no-window -gpu auto -dns-server 8.8.8.8 -noaudio -no-boot-anim -camera-back none -memory 4096 -feature GLDirectMem,HasSharedSlotsHostMemoryAllocator
     strategy:
       fail-fast: false
       matrix:
-        api-level: [ 31, 35 ]
-        target: [ google_apis ]
+        include:
+          - api-level: 31
+            target: google_apis
+          - api-level: 35
+            target: google_apis
+          - api-level: "37.0"
+            target: playstore_ps16k
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -27,6 +34,7 @@ jobs:
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro
+          emulator-options: ${{ env.EMULATOR_OPTIONS }}
           script: |
             adb shell 'echo "_ --disable-fre --no-default-browser-check --no-first-run" > /data/local/tmp/chrome-command-line'
             adb shell chmod 777 /data/local/tmp/chrome-command-line
@@ -40,6 +48,7 @@ jobs:
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_7_pro
+          emulator-options: ${{ env.EMULATOR_OPTIONS }}
           script: |
             adb shell 'echo "_ --disable-fre --no-default-browser-check --no-first-run" > /data/local/tmp/chrome-command-line'
             adb shell chmod 777 /data/local/tmp/chrome-command-line

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      EMULATOR_OPTIONS: -no-window -gpu auto -dns-server 8.8.8.8 -noaudio -no-boot-anim -camera-back none -memory 4096 -feature GLDirectMem,HasSharedSlotsHostMemoryAllocator
+      EMULATOR_OPTIONS: -no-window -gpu swiftshader_indirect -dns-server 8.8.8.8 -noaudio -no-boot-anim -camera-back none -memory 4096 -feature GLDirectMem,HasSharedSlotsHostMemoryAllocator
     strategy:
       fail-fast: false
       matrix:
@@ -14,7 +14,7 @@ jobs:
           - api-level: 35
             target: google_apis
           - api-level: "37.0"
-            target: playstore_ps16k
+            target: google_apis_ps16k
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -35,6 +35,7 @@ jobs:
           arch: x86_64
           profile: pixel_7_pro
           emulator-options: ${{ env.EMULATOR_OPTIONS }}
+          emulator-boot-timeout: 900
           script: |
             adb shell 'echo "_ --disable-fre --no-default-browser-check --no-first-run" > /data/local/tmp/chrome-command-line'
             adb shell chmod 777 /data/local/tmp/chrome-command-line
@@ -49,6 +50,7 @@ jobs:
           arch: x86_64
           profile: pixel_7_pro
           emulator-options: ${{ env.EMULATOR_OPTIONS }}
+          emulator-boot-timeout: 900
           script: |
             adb shell 'echo "_ --disable-fre --no-default-browser-check --no-first-run" > /data/local/tmp/chrome-command-line'
             adb shell chmod 777 /data/local/tmp/chrome-command-line

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -36,6 +36,7 @@ jobs:
           profile: pixel_7_pro
           emulator-options: ${{ env.EMULATOR_OPTIONS }}
           emulator-boot-timeout: 900
+          disk-size: 8G
           script: |
             adb wait-for-device
             printf '_ --disable-fre --no-default-browser-check --no-first-run\n' > chrome-command-line
@@ -53,6 +54,7 @@ jobs:
           profile: pixel_7_pro
           emulator-options: ${{ env.EMULATOR_OPTIONS }}
           emulator-boot-timeout: 900
+          disk-size: 8G
           script: |
             adb wait-for-device
             printf '_ --disable-fre --no-default-browser-check --no-first-run\n' > chrome-command-line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PopupBridge Android Release Notes
 
+## unreleased
+
+* Update Android Gradle Plugin version to 8.13.2
+* Update compileSdkVersion and targetSdkVersion to 37
+
 ## 5.2.0
 
 * Bump `browser-switch` to 3.5.1

--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,9 @@ version = '5.2.1-SNAPSHOT'
 group = "com.braintreepayments"
 
 ext {
-    compileSdkVersion = 36
+    compileSdkVersion = 37
     minSdkVersion = 23
-    targetSdkVersion = 35
+    targetSdkVersion = 37
     versionCode = 19
     versionName = version
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ coreVersion = "1.6.1"
 datastorePreferencesVersion = "1.1.4"
 detekt = "1.23.6"
 deviceAutomatorVersion = "1.0.0"
-gradleVersion = "8.9.1"
+androidGradlePlugin = "8.13.2"
 junitVersion = "4.13.2"
 kotlinAndroidVersion = "2.1.10"
 kotlinxCoroutinesTestVersion = "1.10.2"
@@ -24,7 +24,7 @@ datastore-preferences = { module = "androidx.datastore:datastore-preferences", v
 detekt-rules-libraries = { module = "io.gitlab.arturbosch.detekt:detekt-rules-libraries", version.ref = "detekt" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 device-automator = { module = "com.braintreepayments:device-automator", version.ref = "deviceAutomatorVersion" }
-gradle = { module = "com.android.tools.build:gradle", version.ref = "gradleVersion" }
+gradle = { module = "com.android.tools.build:gradle", version.ref = "androidGradlePlugin" }
 junit = { module = "junit:junit", version.ref = "junitVersion" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlinAndroidVersion" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTestVersion" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Summary of changes
- Bump compileSdk and targetSdk to 37 to enable android 17 support
- Bump AGP version to the latest version that does not require big dependency update
- rename `gradleVersion` to `androidGradlePlugin `
- Add new emulator to CI run 

### AI Usage

**Which AI Agent Was Used?**
- [ ] Copilot 
- [x] Claude 
- [ ] Other (Type Name Here)

**How was AI used?**
NA

**Estimated AI Code Contribution**
- [x] less than 30% 
- [ ] 30 - 60% 
- [ ] 60 - 100% 

### Checklist
- [x] Added a changelog entry
- [x] Tested and confirmed payment flows affected by this change are functioning as expected

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
@noguier 